### PR TITLE
#3979 Injecting mailer instead of use get->('mailer')

### DIFF
--- a/src/Controller/ContextController.php
+++ b/src/Controller/ContextController.php
@@ -25,6 +25,22 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class ContextController extends AbstractController
 {
+
+
+    /**
+     *
+     * @var \Swift_Mailer
+     */
+    private $mailer;
+
+    /**
+     * @required
+     * @param \Swift_Mailer $mailer
+     */
+    public function setMailer(\Swift_Mailer $mailer){
+        $this->mailer = $mailer;
+    }
+
     /**
      * @Route("/room/{roomId}/context")
      *
@@ -278,7 +294,7 @@ class ContextController extends AbstractController
 
                         $message->setBody($body, 'text/plain');
 
-                        $this->get('mailer')->send($message);
+                        $this->mailer->send($message);
 
                         $translator->setSelectedLanguage($savedLanguage);
                     }


### PR DESCRIPTION
Fix roblem described in ticket #3979:

If you click on a room and on "Mitgliedschaft beantragen" (request membership) you get redirected to the request site. If you click "Mitgliedschaft beantragen" there you get an "500 Internal Error".