### PR TITLE
Feature/ms-3787-readfilter (#3787, filtering of search results by read status)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1306,7 +1306,7 @@ services:
     App\Event\UserStatusChangedEvent:
         autowire: false
 
-    App\Event\ReadStatusWillChangeEvent:
+    App\Event\ReadStatusPreChangeEvent:
         autowire: false
 
     App\Event\AccountChangedEvent:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1306,6 +1306,9 @@ services:
     App\Event\UserStatusChangedEvent:
         autowire: false
 
+    App\Event\ReadStatusWillChangeEvent:
+        autowire: false
+
     App\Event\AccountChangedEvent:
         autowire: false
 

--- a/legacy/classes/cs_reader_manager.php
+++ b/legacy/classes/cs_reader_manager.php
@@ -249,7 +249,7 @@ class cs_reader_manager {
                /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
                $eventDispatcher = $symfonyContainer->get('event_dispatcher');
 
-               $readStatusPreChangeEvent = new \App\Event\ReadStatusPreChangeEvent($userId, $itemId, 'seen');
+               $readStatusPreChangeEvent = new \App\Event\ReadStatusPreChangeEvent($userId, $itemId, \App\Utils\ReaderService::READ_STATUS_SEEN);
                $eventDispatcher->dispatch($readStatusPreChangeEvent, \App\Event\ReadStatusPreChangeEvent::class);
            }
        }

--- a/legacy/classes/cs_reader_manager.php
+++ b/legacy/classes/cs_reader_manager.php
@@ -243,14 +243,14 @@ class cs_reader_manager {
                    . '")';
                $valueRows[] = $valueRow;
 
-               // fire a ReadStatusWillChangeEvent (which will e.g. trigger invalidation of the read status cache for this item & user)
+               // fire a ReadStatusPreChangeEvent (which will e.g. trigger invalidation of the read status cache for this item & user)
                global $symfonyContainer;
 
                /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
                $eventDispatcher = $symfonyContainer->get('event_dispatcher');
 
-               $readStatusWillChangeEvent = new \App\Event\ReadStatusWillChangeEvent($userId, $itemId, 'seen');
-               $eventDispatcher->dispatch($readStatusWillChangeEvent, \App\Event\ReadStatusWillChangeEvent::class);
+               $readStatusPreChangeEvent = new \App\Event\ReadStatusPreChangeEvent($userId, $itemId, 'seen');
+               $eventDispatcher->dispatch($readStatusPreChangeEvent, \App\Event\ReadStatusPreChangeEvent::class);
            }
        }
        $query .= implode(', ', $valueRows);

--- a/legacy/classes/cs_reader_manager.php
+++ b/legacy/classes/cs_reader_manager.php
@@ -242,6 +242,15 @@ class cs_reader_manager {
                    . $currentDateTime
                    . '")';
                $valueRows[] = $valueRow;
+
+               // fire a ReadStatusWillChangeEvent (which will e.g. trigger invalidation of the read status cache for this item & user)
+               global $symfonyContainer;
+
+               /** @var \Symfony\Component\EventDispatcher\EventDispatcher $eventDispatcher */
+               $eventDispatcher = $symfonyContainer->get('event_dispatcher');
+
+               $readStatusWillChangeEvent = new \App\Event\ReadStatusWillChangeEvent($userId, $itemId, 'seen');
+               $eventDispatcher->dispatch($readStatusWillChangeEvent, \App\Event\ReadStatusWillChangeEvent::class);
            }
        }
        $query .= implode(', ', $valueRows);

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -487,14 +487,14 @@ class SearchController extends BaseController
         }
 
         // user room IDs / read status parameter
-        // NOTE: we always restrict the search to either the context IDs of the current user's rooms, or to item IDs
-        // matching the currently selected read status (which is a user-specific property and thus isn't indexed)
+        // NOTE: we always restrict the search to the context IDs of the current user's rooms, and possibly to item
+        // IDs matching the currently selected read status (which is a user-specific property and thus isn't indexed)
         // WARNING: this acts as a PRE-filtering mechanism which can slow things down substantially and ideally
         // wouldn't be necessary
+        $searchManager->addFilterCondition($multipleContextFilterCondition);
+
         $selectedReadStatus = $searchData->getSelectedReadStatus();
-        if (empty($selectedReadStatus) || $selectedReadStatus === 'all') {
-            $searchManager->addFilterCondition($multipleContextFilterCondition);
-        } else {
+        if (!empty($selectedReadStatus) && $selectedReadStatus !== 'all') {
             $readStatusFilterCondition->setReadStatus($selectedReadStatus);
             $searchManager->addFilterCondition($readStatusFilterCondition);
         }

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -487,14 +487,14 @@ class SearchController extends BaseController
         }
 
         // user room IDs / read status parameter
-        // NOTE: we always restrict the search to the context IDs of the current user's rooms, and possibly to item
-        // IDs matching the currently selected read status (which is a user-specific property and thus isn't indexed)
+        // NOTE: we always restrict the search to either the context IDs of the current user's rooms, or to item IDs
+        // matching the currently selected read status (which is a user-specific property and thus isn't indexed)
         // WARNING: this acts as a PRE-filtering mechanism which can slow things down substantially and ideally
         // wouldn't be necessary
-        $searchManager->addFilterCondition($multipleContextFilterCondition);
-
         $selectedReadStatus = $searchData->getSelectedReadStatus();
-        if (!empty($selectedReadStatus) && $selectedReadStatus !== 'all') {
+        if (empty($selectedReadStatus) || $selectedReadStatus === 'all') {
+            $searchManager->addFilterCondition($multipleContextFilterCondition);
+        } else {
             $readStatusFilterCondition->setReadStatus($selectedReadStatus);
             $searchManager->addFilterCondition($readStatusFilterCondition);
         }

--- a/src/Event/ReadStatusPreChangeEvent.php
+++ b/src/Event/ReadStatusPreChangeEvent.php
@@ -10,10 +10,10 @@ use Symfony\Contracts\EventDispatcher\Event;
  * This event is fired when an item's read status will be changed for a user.
  * For available read status values, see the constants defined in `ReaderService`.
  *
- * Class ReadStatusWillChangeEvent
+ * Class ReadStatusPreChangeEvent
  * @package App\Event
  */
-class ReadStatusWillChangeEvent extends Event
+class ReadStatusPreChangeEvent extends Event
 {
     /**
      * @var int $userId

--- a/src/Event/ReadStatusPreChangeEvent.php
+++ b/src/Event/ReadStatusPreChangeEvent.php
@@ -4,6 +4,7 @@
 namespace App\Event;
 
 
+use App\Utils\ReaderService;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -32,6 +33,17 @@ class ReadStatusPreChangeEvent extends Event
 
     public function __construct(int $userId, int $itemId, string $newReadStatus)
     {
+        if (
+            $newReadStatus !== ReaderService::READ_STATUS_NEW &&
+            $newReadStatus !== ReaderService::READ_STATUS_CHANGED &&
+            $newReadStatus !== ReaderService::READ_STATUS_NEW_ANNOTATION &&
+            $newReadStatus !== ReaderService::READ_STATUS_CHANGED_ANNOTATION &&
+            $newReadStatus !== ReaderService::READ_STATUS_SEEN &&
+            !empty($newReadStatus) // most CommSy code currently uses an empty string ('') instead of READ_STATUS_SEEN
+        ) {
+            throw new \InvalidArgumentException('unknown read status given');
+        }
+
         $this->userId = $userId;
         $this->itemId = $itemId;
         $this->newReadStatus = $newReadStatus;

--- a/src/Event/ReadStatusWillChangeEvent.php
+++ b/src/Event/ReadStatusWillChangeEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+
+namespace App\Event;
+
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * This event is fired when an item's read status will be changed for a user.
+ * For available read status values, see the constants defined in `ReaderService`.
+ *
+ * Class ReadStatusWillChangeEvent
+ * @package App\Event
+ */
+class ReadStatusWillChangeEvent extends Event
+{
+    /**
+     * @var int $userId
+     */
+    private $userId;
+
+    /**
+     * @var int $itemId
+     */
+    private $itemId;
+
+    /**
+     * @var string $newReadStatus
+     */
+    private $newReadStatus;
+
+    public function __construct(int $userId, int $itemId, string $newReadStatus)
+    {
+        $this->userId = $userId;
+        $this->itemId = $itemId;
+        $this->newReadStatus = $newReadStatus;
+    }
+
+    /**
+     * The ID of the user for which the item's read status will be changed.
+     * @return int
+     */
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    /**
+     * The ID of the item whose read status will be changed.
+     * Note that the returned item may still have the old read status assigned.
+     * @return int
+     */
+    public function getItemId(): int
+    {
+        return $this->itemId;
+    }
+
+    /**
+     * The new read status that will be assigned to the item.
+     * @return string
+     */
+    public function getNewReadStatus(): string
+    {
+        return $this->newReadStatus;
+    }
+}

--- a/src/EventSubscriber/CommsyEditSubscriber.php
+++ b/src/EventSubscriber/CommsyEditSubscriber.php
@@ -50,6 +50,8 @@ class CommsyEditSubscriber implements EventSubscriberInterface {
             if (method_exists($item, 'updateElastic')) {
                 $item->updateElastic();
 
+                // NOTE: read status cache items also get invalidated via the ReadStatusWillChangeEvent
+                // which will be triggered when items get marked as read
                 $this->readerService->invalidateCachedReadStatusForItem($item);
             }
         }

--- a/src/EventSubscriber/CommsyEditSubscriber.php
+++ b/src/EventSubscriber/CommsyEditSubscriber.php
@@ -50,7 +50,7 @@ class CommsyEditSubscriber implements EventSubscriberInterface {
             if (method_exists($item, 'updateElastic')) {
                 $item->updateElastic();
 
-                // NOTE: read status cache items also get invalidated via the ReadStatusWillChangeEvent
+                // NOTE: read status cache items also get invalidated via the ReadStatusPreChangeEvent
                 // which will be triggered when items get marked as read
                 $this->readerService->invalidateCachedReadStatusForItem($item);
             }

--- a/src/EventSubscriber/CommsyEditSubscriber.php
+++ b/src/EventSubscriber/CommsyEditSubscriber.php
@@ -2,18 +2,27 @@
 
 namespace App\EventSubscriber;
 
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 use App\Event\CommsyEditEvent;
+use App\Utils\ReaderService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class CommsyEditSubscriber implements EventSubscriberInterface {
 
+    /**
+     * @var ContainerInterface $container
+     */
     private $container;
 
-    public function __construct(ContainerInterface $container)
+    /**
+     * @var ReaderService $readerService
+     */
+    private $readerService;
+
+    public function __construct(ContainerInterface $container, ReaderService $readerService)
     {
         $this->container = $container;
+        $this->readerService = $readerService;
     }
 
     public function onCommsyEdit(CommsyEditEvent $event) {
@@ -26,6 +35,7 @@ class CommsyEditSubscriber implements EventSubscriberInterface {
 
     public function onCommsySave(CommsyEditEvent $event) {
         if ($event->getItem()) {
+            /** @var \cs_item $item */
             $item = $event->getItem();
 
             if ($item->hasLocking()) {
@@ -39,6 +49,8 @@ class CommsyEditSubscriber implements EventSubscriberInterface {
 
             if (method_exists($item, 'updateElastic')) {
                 $item->updateElastic();
+
+                $this->readerService->invalidateCachedReadStatusForItem($item);
             }
         }
     }

--- a/src/EventSubscriber/ReadStatusSubscriber.php
+++ b/src/EventSubscriber/ReadStatusSubscriber.php
@@ -4,7 +4,7 @@
 namespace App\EventSubscriber;
 
 
-use App\Event\ReadStatusWillChangeEvent;
+use App\Event\ReadStatusPreChangeEvent;
 use App\Utils\ItemService;
 use App\Utils\ReaderService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -30,11 +30,11 @@ class ReadStatusSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ReadStatusWillChangeEvent::class => 'onReadStatusWillChange',
+            ReadStatusPreChangeEvent::class => 'onReadStatusPreChange',
         ];
     }
 
-    public function onReadStatusWillChange(ReadStatusWillChangeEvent $event)
+    public function onReadStatusPreChange(ReadStatusPreChangeEvent $event)
     {
         $itemId = $event->getItemId();
 

--- a/src/EventSubscriber/ReadStatusSubscriber.php
+++ b/src/EventSubscriber/ReadStatusSubscriber.php
@@ -43,6 +43,16 @@ class ReadStatusSubscriber implements EventSubscriberInterface
             return;
         }
 
+        // for annotations, invalidate the read status cache of their linked (hosting) item
+        if ($item->getItemType() === CS_ANNOTATION_TYPE) {
+            /** @var \cs_annotation_item $annotation */
+            $annotation = $this->itemService->getTypedItem($itemId);
+            $linkedItem = $annotation->getLinkedItem();
+            if ($linkedItem) {
+                $item = $linkedItem;
+            }
+        }
+
         $this->readerService->invalidateCachedReadStatusForItem($item);
     }
 }

--- a/src/EventSubscriber/ReadStatusSubscriber.php
+++ b/src/EventSubscriber/ReadStatusSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace App\EventSubscriber;
+
+
+use App\Event\ReadStatusWillChangeEvent;
+use App\Utils\ItemService;
+use App\Utils\ReaderService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ReadStatusSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var ItemService $itemService
+     */
+    private $itemService;
+
+    /**
+     * @var ReaderService $readerService
+     */
+    private $readerService;
+
+    public function __construct(ItemService $itemService, ReaderService $readerService)
+    {
+        $this->itemService = $itemService;
+        $this->readerService = $readerService;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ReadStatusWillChangeEvent::class => 'onReadStatusWillChange',
+        ];
+    }
+
+    public function onReadStatusWillChange(ReadStatusWillChangeEvent $event)
+    {
+        $itemId = $event->getItemId();
+
+        $item = $this->itemService->getItem($itemId);
+        if (!$item) {
+            return;
+        }
+
+        $this->readerService->invalidateCachedReadStatusForItem($item);
+    }
+}

--- a/src/Filter/SearchFilterType.php
+++ b/src/Filter/SearchFilterType.php
@@ -4,6 +4,7 @@ namespace App\Filter;
 use App\Form\Type\Custom\Select2ChoiceType;
 use App\Model\SearchData;
 use App\Search\SearchManager;
+use App\Utils\ReaderService;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -136,6 +137,20 @@ class SearchFilterType extends AbstractType
                     return array_merge([$translatedTitleAny => 'all'], $this->buildRubricsChoices($searchData->getRubrics()));
                 }),
                 'label' => 'Rubric',
+                'required' => false,
+                'placeholder' => false,
+            ])
+            ->add('selectedReadStatus', Types\ChoiceType::class, [
+                'attr' => [
+                    'onchange' => 'this.form.submit()',
+                ],
+                'choices' => [
+                    $this->translator->trans('any', [], 'form') => 'all',
+                    'New' => ReaderService::READ_STATUS_NEW,
+                    'Modified' => ReaderService::READ_STATUS_CHANGED,
+                    'Read' => ReaderService::READ_STATUS_SEEN,
+                ],
+                'label' => 'Read status',
                 'required' => false,
                 'placeholder' => false,
             ])

--- a/src/Model/SearchData.php
+++ b/src/Model/SearchData.php
@@ -19,6 +19,11 @@ class SearchData
     private $appearsInDescription;
 
     /**
+     * @var string|null
+     */
+    private $selectedReadStatus;
+
+    /**
      * @var array|null associative array of rubrics (key: rubric name, value: count)
      */
     private $rubrics;
@@ -163,6 +168,24 @@ class SearchData
     public function setAppearsInDescription(bool $appearsInDescription): SearchData
     {
         $this->appearsInDescription = $appearsInDescription;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSelectedReadStatus(): ?string
+    {
+        return $this->selectedReadStatus;
+    }
+
+    /**
+     * @param string|null $selectedReadStatus
+     * @return SearchData
+     */
+    public function setSelectedReadStatus(?string $selectedReadStatus): SearchData
+    {
+        $this->selectedReadStatus = $selectedReadStatus;
         return $this;
     }
 

--- a/src/Model/SearchData.php
+++ b/src/Model/SearchData.php
@@ -103,9 +103,9 @@ class SearchData
 
     /**
      * @param string|null $phrase
-     * @return SearchData
+     * @return self
      */
-    public function setPhrase(?string $phrase): SearchData
+    public function setPhrase(?string $phrase): self
     {
         $this->phrase = $phrase;
         return $this;
@@ -128,9 +128,9 @@ class SearchData
 
     /**
      * @param array $appearsIn an array of field names describing the fields that must contain a search term
-     * @return SearchData
+     * @return self
      */
-    public function setAppearsIn(array $appearsIn): SearchData
+    public function setAppearsIn(array $appearsIn): self
     {
         $this->setAppearsInTitle(in_array('title', $appearsIn, true) ? true : false);
         $this->setAppearsInDescription(in_array('description', $appearsIn, true) ? true : false);
@@ -148,7 +148,7 @@ class SearchData
     /**
      * @param boolean $appearsInTitle
      */
-    public function setAppearsInTitle(bool $appearsInTitle): SearchData
+    public function setAppearsInTitle(bool $appearsInTitle): self
     {
         $this->appearsInTitle = $appearsInTitle;
         return $this;
@@ -165,7 +165,7 @@ class SearchData
     /**
      * @param boolean $appearsInDescription
      */
-    public function setAppearsInDescription(bool $appearsInDescription): SearchData
+    public function setAppearsInDescription(bool $appearsInDescription): self
     {
         $this->appearsInDescription = $appearsInDescription;
         return $this;
@@ -181,9 +181,9 @@ class SearchData
 
     /**
      * @param string|null $selectedReadStatus
-     * @return SearchData
+     * @return self
      */
-    public function setSelectedReadStatus(?string $selectedReadStatus): SearchData
+    public function setSelectedReadStatus(?string $selectedReadStatus): self
     {
         $this->selectedReadStatus = $selectedReadStatus;
         return $this;
@@ -199,9 +199,9 @@ class SearchData
 
     /**
      * @param array $rubrics associative array of rubrics (key: rubric name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function setRubrics(array $rubrics): SearchData
+    public function setRubrics(array $rubrics): self
     {
         $this->rubrics = $rubrics;
         return $this;
@@ -209,9 +209,9 @@ class SearchData
 
     /**
      * @param array $rubrics associative array of rubrics (key: rubric name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function addRubrics(array $rubrics): SearchData
+    public function addRubrics(array $rubrics): self
     {
         foreach ($rubrics as $name => $count) {
             $this->rubrics[$name] = $count;
@@ -229,9 +229,9 @@ class SearchData
 
     /**
      * @param string|null $selectedRubric
-     * @return SearchData
+     * @return self
      */
-    public function setSelectedRubric(?string $selectedRubric): SearchData
+    public function setSelectedRubric(?string $selectedRubric): self
     {
         $this->selectedRubric = $selectedRubric;
         return $this;
@@ -247,9 +247,9 @@ class SearchData
 
     /**
      * @param array $creators associative array of creators (key: creator name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function setCreators(array $creators): SearchData
+    public function setCreators(array $creators): self
     {
         $this->creators = $creators;
         return $this;
@@ -257,9 +257,9 @@ class SearchData
 
     /**
      * @param array $creators associative array of creators (key: creator name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function addCreators(array $creators): SearchData
+    public function addCreators(array $creators): self
     {
         foreach ($creators as $name => $count) {
             $this->creators[$name] = $count;
@@ -277,9 +277,9 @@ class SearchData
 
     /**
      * @param string|null $selectedCreator
-     * @return SearchData
+     * @return self
      */
-    public function setSelectedCreator(?string $selectedCreator): SearchData
+    public function setSelectedCreator(?string $selectedCreator): self
     {
         $this->selectedCreator = $selectedCreator;
         return $this;
@@ -295,9 +295,9 @@ class SearchData
 
     /**
      * @param array $hashtags associative array of hashtags (key: hashtag name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function setHashtags(array $hashtags): SearchData
+    public function setHashtags(array $hashtags): self
     {
         $this->hashtags = $hashtags;
         return $this;
@@ -305,9 +305,9 @@ class SearchData
 
     /**
      * @param array $hashtags associative array of hashtags (key: hashtag name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function addHashtags(array $hashtags): SearchData
+    public function addHashtags(array $hashtags): self
     {
         foreach ($hashtags as $name => $count) {
             $this->hashtags[$name] = $count;
@@ -325,9 +325,9 @@ class SearchData
 
     /**
      * @param string[] $selectedHashtags
-     * @return SearchData
+     * @return self
      */
-    public function setSelectedHashtags(array $selectedHashtags): SearchData
+    public function setSelectedHashtags(array $selectedHashtags): self
     {
         $this->selectedHashtags = $selectedHashtags;
         return $this;
@@ -343,9 +343,9 @@ class SearchData
 
     /**
      * @param array $categories associative array of categories (key: category name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function setCategories(array $categories): SearchData
+    public function setCategories(array $categories): self
     {
         $this->categories = $categories;
         return $this;
@@ -353,9 +353,9 @@ class SearchData
 
     /**
      * @param array $categories associative array of categories (key: category name, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function addCategories(array $categories): SearchData
+    public function addCategories(array $categories): self
     {
         foreach ($categories as $name => $count) {
             $this->categories[$name] = $count;
@@ -373,9 +373,9 @@ class SearchData
 
     /**
      * @param string[] $selectedCategories
-     * @return SearchData
+     * @return self
      */
-    public function setSelectedCategories(array $selectedCategories): SearchData
+    public function setSelectedCategories(array $selectedCategories): self
     {
         $this->selectedCategories = $selectedCategories;
         return $this;
@@ -394,9 +394,9 @@ class SearchData
 
     /**
      * @param array|null $creationDateRange an array of two items, start & end date, which may be \DateTime objects or null
-     * @return SearchData
+     * @return self
      */
-    public function setCreationDateRange(?array $creationDateRange): SearchData
+    public function setCreationDateRange(?array $creationDateRange): self
     {
         // start date
         if (isset($creationDateRange[0]) && $creationDateRange[0] instanceof \DateTime) {
@@ -422,9 +422,9 @@ class SearchData
 
     /**
      * @param array|null $modificationDateRange an array of two items, start & end date, which may be \DateTime objects or null
-     * @return SearchData
+     * @return self
      */
-    public function setModificationDateRange(?array $modificationDateRange): SearchData
+    public function setModificationDateRange(?array $modificationDateRange): self
     {
         if (isset($modificationDateRange[0]) && $modificationDateRange[0] instanceof \DateTime) {
             $this->setModificationDateFrom($modificationDateRange[0]);
@@ -445,9 +445,9 @@ class SearchData
 
     /**
      * @param \DateTime|null $creationDateFrom
-     * @return SearchData
+     * @return self
      */
-    public function setCreationDateFrom(?\DateTime $creationDateFrom): SearchData
+    public function setCreationDateFrom(?\DateTime $creationDateFrom): self
     {
         $this->creationDateFrom = $creationDateFrom;
         return $this;
@@ -463,9 +463,9 @@ class SearchData
 
     /**
      * @param \DateTime|null $creationDateUntil
-     * @return SearchData
+     * @return self
      */
-    public function setCreationDateUntil(?\DateTime $creationDateUntil): SearchData
+    public function setCreationDateUntil(?\DateTime $creationDateUntil): self
     {
         $this->creationDateUntil = $creationDateUntil;
         return $this;
@@ -481,9 +481,9 @@ class SearchData
 
     /**
      * @param \DateTime|null $modificationDateFrom
-     * @return SearchData
+     * @return self
      */
-    public function setModificationDateFrom(?\DateTime $modificationDateFrom): SearchData
+    public function setModificationDateFrom(?\DateTime $modificationDateFrom): self
     {
         $this->modificationDateFrom = $modificationDateFrom;
         return $this;
@@ -499,9 +499,9 @@ class SearchData
 
     /**
      * @param \DateTime|null $modificationDateUntil
-     * @return SearchData
+     * @return self
      */
-    public function setModificationDateUntil(?\DateTime $modificationDateUntil): SearchData
+    public function setModificationDateUntil(?\DateTime $modificationDateUntil): self
     {
         $this->modificationDateUntil = $modificationDateUntil;
         return $this;
@@ -533,9 +533,9 @@ class SearchData
 
     /**
      * @param string|null $selectedContext
-     * @return SearchData
+     * @return self
      */
-    public function setSelectedContext(?string $selectedContext): SearchData
+    public function setSelectedContext(?string $selectedContext): self
     {
         $this->selectedContext = $selectedContext;
         return $this;
@@ -543,9 +543,9 @@ class SearchData
 
     /**
      * @param array $contexts associative array of context titles (key: context title, value: count)
-     * @return SearchData
+     * @return self
      */
-    public function addContexts(array $contexts): SearchData
+    public function addContexts(array $contexts): self
     {
         foreach ($contexts as $name => $count) {
             $this->contexts[$name] = $count;

--- a/src/Search/FilterConditions/MultipleContextFilterCondition.php
+++ b/src/Search/FilterConditions/MultipleContextFilterCondition.php
@@ -24,12 +24,12 @@ class MultipleContextFilterCondition implements FilterConditionInterface
      */
     public function getConditions(): array
     {
-        $searchableRooms = $this->userService->getSearchableRooms($this->userService->getCurrentUserItem());
+        $currentUser = $this->userService->getCurrentUserItem();
+        $searchableRooms = $this->userService->getSearchableRooms($currentUser);
 
-        $contextIds = [];
-        foreach ($searchableRooms as $searchableRoom) {
-            $contextIds[] = $searchableRoom->getItemId();
-        }
+        $contextIds = array_map(function (\cs_room_item $room) {
+            return $room->getItemID();
+        }, $searchableRooms);
 
         $contextFilter = new Terms();
         $contextFilter->setTerms('contextId', $contextIds);

--- a/src/Search/FilterConditions/ReadStatusFilterCondition.php
+++ b/src/Search/FilterConditions/ReadStatusFilterCondition.php
@@ -73,25 +73,7 @@ class ReadStatusFilterCondition implements FilterConditionInterface
         $items = $this->itemService->getSearchableItemsForContextIds($contextIds);
 
         // extract the IDs of all items with a read status matching the one in `$this->readStatus`
-        $itemIds = [];
-        foreach ($items as $item) {
-            if ($item) {
-                $relatedUser = $currentUser->getRelatedUserItemInContext($item->getContextId());
-                if ($relatedUser) {
-                    $itemId = $item->getItemId();
-                    $readStatus = $this->readerService->getChangeStatusForUserByID($itemId, $relatedUser->getItemId());
-
-                    // NOTE: instead of READ_STATUS_SEEN, ReaderService currently returns an empty string (''); also,
-                    // we treat READ_STATUS_NEW_ANNOTATION like READ_STATUS_NEW, and READ_STATUS_CHANGED_ANNOTATION
-                    // like READ_STATUS_CHANGED
-                    if (empty($readStatus) && $this->readStatus === ReaderService::READ_STATUS_SEEN
-                        || strpos($readStatus, $this->readStatus) === 0) {
-                        $itemIds[] = $itemId;
-                    }
-                }
-            }
-        }
-
+        $itemIds = $this->readerService->itemIdsForReadStatus($items, $this->readStatus, $currentUser);
         if (empty($itemIds)) {
             return [];
         }

--- a/src/Search/FilterConditions/ReadStatusFilterCondition.php
+++ b/src/Search/FilterConditions/ReadStatusFilterCondition.php
@@ -74,9 +74,6 @@ class ReadStatusFilterCondition implements FilterConditionInterface
 
         // extract the IDs of all items with a read status matching the one in `$this->readStatus`
         $itemIds = $this->readerService->itemIdsForReadStatus($items, $this->readStatus, $currentUser);
-        if (empty($itemIds)) {
-            return [];
-        }
 
         $contextFilter = new Ids();
         $contextFilter->setIds($itemIds);

--- a/src/Search/FilterConditions/ReadStatusFilterCondition.php
+++ b/src/Search/FilterConditions/ReadStatusFilterCondition.php
@@ -55,6 +55,13 @@ class ReadStatusFilterCondition implements FilterConditionInterface
      */
     public function getConditions(): array
     {
+        // WARNING: this method potentially iterates over a very large number of items, i.e. this may be very slow!
+
+        if (empty($this->readStatus)) {
+            return [];
+        }
+
+        // get IDs of the user's rooms
         $currentUser = $this->userService->getCurrentUserItem();
         $searchableRooms = $this->userService->getSearchableRooms($currentUser);
 
@@ -62,9 +69,11 @@ class ReadStatusFilterCondition implements FilterConditionInterface
             return $room->getItemID();
         }, $searchableRooms);
 
-        $items = $this->itemService->getItemsForContextIds($contextIds);
+        // get all searchable items from the user's rooms
+        $items = $this->itemService->getSearchableItemsForContextIds($contextIds);
 
-        // extract the item IDs of all items having a read status of that set in `$readStatus`
+        // extract the IDs of all items with a read status matching the one in `$this->readStatus`
+// TODO: handle ReaderService::READ_STATUS_SEEN
         $itemIds = [];
         foreach ($items as $item) {
             if ($item) {

--- a/src/Search/FilterConditions/ReadStatusFilterCondition.php
+++ b/src/Search/FilterConditions/ReadStatusFilterCondition.php
@@ -81,7 +81,9 @@ class ReadStatusFilterCondition implements FilterConditionInterface
                 if ($relatedUser) {
                     $itemId = $item->getItemId();
                     $readStatus = $this->readerService->getChangeStatusForUserByID($itemId, $relatedUser->getItemId());
-                    if ($readStatus === $this->readStatus) {
+                    // READ_STATUS_NEW_ANNOTATION is treated like READ_STATUS_NEW, and READ_STATUS_CHANGED_ANNOTATION
+                    // is treated like READ_STATUS_CHANGED
+                    if (strpos($readStatus, $this->readStatus) === 0) {
                         $itemIds[] = $itemId;
                     }
                 }

--- a/src/Search/FilterConditions/ReadStatusFilterCondition.php
+++ b/src/Search/FilterConditions/ReadStatusFilterCondition.php
@@ -1,0 +1,99 @@
+<?php
+
+
+namespace App\Search\FilterConditions;
+
+
+use App\Utils\ItemService;
+use App\Utils\ReaderService;
+use App\Utils\UserService;
+use Elastica\Query\Ids;
+
+class ReadStatusFilterCondition implements FilterConditionInterface
+{
+    /**
+     * @var UserService $userService
+     */
+    private $userService;
+
+    /**
+     * @var ItemService $itemService
+     */
+    private $itemService;
+
+    /**
+     * @var ReaderService $readerService
+     */
+    private $readerService;
+
+    /**
+     * @var string $readStatus
+     */
+    private $readStatus;
+
+    public function __construct(UserService $userService, ItemService $itemService, ReaderService $readerService)
+    {
+        $this->userService = $userService;
+        $this->itemService = $itemService;
+        $this->readerService = $readerService;
+    }
+
+    /**
+     * Sets the read status to be used as a filter condition.
+     * Read status must be: ReaderService::READ_STATUS_NEW, ReaderService::READ_STATUS_CHANGED or ReaderService::READ_STATUS_SEEN
+     * @param string $readStatus
+     * @return self
+     */
+    public function setReadStatus(string $readStatus): self
+    {
+        $this->readStatus = $readStatus;
+        return $this;
+    }
+
+    /**
+     * @return Ids[]
+     */
+    public function getConditions(): array
+    {
+        $currentUser = $this->userService->getCurrentUserItem();
+        $searchableRooms = $this->userService->getSearchableRooms($currentUser);
+
+        $contextIds = array_map(function (\cs_room_item $room) {
+            return $room->getItemID();
+        }, $searchableRooms);
+
+        $items = $this->itemService->getItemsForContextIds($contextIds);
+
+        // extract the item IDs of all items having a read status of that set in `$readStatus`
+        $itemIds = [];
+        foreach ($items as $item) {
+            if ($item) {
+                $relatedUser = $currentUser->getRelatedUserItemInContext($item->getContextId());
+                if ($relatedUser) {
+                    $itemId = $item->getItemId();
+                    $readStatus = $this->readerService->getChangeStatusForUserByID($itemId, $relatedUser->getItemId());
+                    if ($readStatus === $this->readStatus) {
+                        $itemIds[] = $itemId;
+                    }
+                }
+            }
+        }
+
+        if (empty($itemIds)) {
+            return [];
+        }
+
+        $contextFilter = new Ids();
+        $contextFilter->setIds($itemIds);
+
+        return [$contextFilter];
+    }
+
+    /**
+     * @return string
+     */
+    public function getOperator(): string
+    {
+        return FilterConditionInterface::BOOL_MUST;
+    }
+}

--- a/src/Search/FilterConditions/ReadStatusFilterCondition.php
+++ b/src/Search/FilterConditions/ReadStatusFilterCondition.php
@@ -73,7 +73,6 @@ class ReadStatusFilterCondition implements FilterConditionInterface
         $items = $this->itemService->getSearchableItemsForContextIds($contextIds);
 
         // extract the IDs of all items with a read status matching the one in `$this->readStatus`
-// TODO: handle ReaderService::READ_STATUS_SEEN
         $itemIds = [];
         foreach ($items as $item) {
             if ($item) {
@@ -81,9 +80,12 @@ class ReadStatusFilterCondition implements FilterConditionInterface
                 if ($relatedUser) {
                     $itemId = $item->getItemId();
                     $readStatus = $this->readerService->getChangeStatusForUserByID($itemId, $relatedUser->getItemId());
-                    // READ_STATUS_NEW_ANNOTATION is treated like READ_STATUS_NEW, and READ_STATUS_CHANGED_ANNOTATION
-                    // is treated like READ_STATUS_CHANGED
-                    if (strpos($readStatus, $this->readStatus) === 0) {
+
+                    // NOTE: instead of READ_STATUS_SEEN, ReaderService currently returns an empty string (''); also,
+                    // we treat READ_STATUS_NEW_ANNOTATION like READ_STATUS_NEW, and READ_STATUS_CHANGED_ANNOTATION
+                    // like READ_STATUS_CHANGED
+                    if (empty($readStatus) && $this->readStatus === ReaderService::READ_STATUS_SEEN
+                        || strpos($readStatus, $this->readStatus) === 0) {
                         $itemIds[] = $itemId;
                     }
                 }

--- a/src/Utils/ItemService.php
+++ b/src/Utils/ItemService.php
@@ -53,6 +53,9 @@ class ItemService
             }
             
             $manager = $this->legacyEnvironment->getManager($type);
+            if (!$manager) {
+                return null;
+            }
 
             if ($versionId === null) {
                 return $manager->getItem($item->getItemID());

--- a/src/Utils/ItemService.php
+++ b/src/Utils/ItemService.php
@@ -3,7 +3,6 @@
 namespace App\Utils;
 
 use App\Services\LegacyEnvironment;
-use cs_userroom_item;
 
 class ItemService
 {
@@ -150,7 +149,7 @@ class ItemService
      * @param integer[] $contextIds array of room IDs for rooms whose items shall be returned
      * @return \cs_item[]
      */
-    public function getSearchableItemsForContextIds(array $contextIds)
+    public function getSearchableItemsForContextIds(array $contextIds): array
     {
         if (empty($contextIds)) {
             return [];
@@ -165,7 +164,7 @@ class ItemService
             CS_MATERIAL_TYPE,
             CS_TODO_TYPE,
             CS_USER_TYPE,
-            cs_userroom_item::ROOM_TYPE_USER,
+            \cs_userroom_item::ROOM_TYPE_USER,
         ];
 
         $itemManager->resetLimits();

--- a/src/Utils/ItemService.php
+++ b/src/Utils/ItemService.php
@@ -2,14 +2,18 @@
 
 namespace App\Utils;
 
-use Symfony\Component\Form\Form;
-
 use App\Services\LegacyEnvironment;
 
 class ItemService
 {
+    /**
+     * @var LegacyEnvironment $legacyEnvironment
+     */
     private $legacyEnvironment;
 
+    /**
+     * @var \cs_item_manager $itemManager
+     */
     private $itemManager;
 
     public function __construct(LegacyEnvironment $legacyEnvironment)
@@ -135,6 +139,30 @@ class ItemService
         }
 
         return [];
+    }
+
+    /**
+     * Returns all items contained in rooms specified by the given room IDs.
+     * @param integer[] $contextIds array of room IDs for rooms whose items shall be returned
+     * @return \cs_item[]
+     */
+    public function getItemsForContextIds(array $contextIds)
+    {
+        if (empty($contextIds)) {
+            return [];
+        }
+
+        $itemManager = $this->itemManager;
+
+        $itemManager->resetLimits();
+        $itemManager->setContextArrayLimit($contextIds);
+
+        $itemManager->select();
+
+        /** @var \cs_list $itemList */
+        $itemList = $itemManager->get();
+
+        return $itemList->to_array();
     }
 
     /**

--- a/src/Utils/ItemService.php
+++ b/src/Utils/ItemService.php
@@ -158,11 +158,9 @@ class ItemService
             CS_ANNOUNCEMENT_TYPE,
             CS_DATE_TYPE,
             CS_DISCUSSION_TYPE,
-            CS_GROUP_TYPE,
-            CS_INSTITUTION_TYPE,
+            CS_LABEL_TYPE, // groups, topics & institutions
             CS_MATERIAL_TYPE,
             CS_TODO_TYPE,
-            CS_TOPIC_TYPE,
             CS_USER_TYPE,
             cs_userroom_item::ROOM_TYPE_USER,
         ];

--- a/src/Utils/ItemService.php
+++ b/src/Utils/ItemService.php
@@ -3,6 +3,7 @@
 namespace App\Utils;
 
 use App\Services\LegacyEnvironment;
+use cs_userroom_item;
 
 class ItemService
 {
@@ -142,19 +143,33 @@ class ItemService
     }
 
     /**
-     * Returns all items contained in rooms specified by the given room IDs.
+     * Returns all searchable items contained in rooms specified by the given room IDs.
      * @param integer[] $contextIds array of room IDs for rooms whose items shall be returned
      * @return \cs_item[]
      */
-    public function getItemsForContextIds(array $contextIds)
+    public function getSearchableItemsForContextIds(array $contextIds)
     {
         if (empty($contextIds)) {
             return [];
         }
 
         $itemManager = $this->itemManager;
+        $searchableTypes = [
+            CS_ANNOUNCEMENT_TYPE,
+            CS_DATE_TYPE,
+            CS_DISCUSSION_TYPE,
+            CS_GROUP_TYPE,
+            CS_INSTITUTION_TYPE,
+            CS_MATERIAL_TYPE,
+            CS_TODO_TYPE,
+            CS_TOPIC_TYPE,
+            CS_USER_TYPE,
+            cs_userroom_item::ROOM_TYPE_USER,
+        ];
 
         $itemManager->resetLimits();
+        $itemManager->setNoIntervalLimit();
+        $itemManager->setTypeArrayLimit($searchableTypes);
         $itemManager->setContextArrayLimit($contextIds);
 
         $itemManager->select();

--- a/src/Utils/ReaderService.php
+++ b/src/Utils/ReaderService.php
@@ -8,31 +8,32 @@ use App\Utils\ItemService;
 class ReaderService
 {
     /**
-     * Read status constant that identifies a "new" item, i.e. an item that hasn't been seen before
+     * Read status constant that identifies a "new" item, i.e. an item that hasn't been seen before.
      * @var string
      */
     public const READ_STATUS_NEW = 'new';
 
     /**
-     * Read status constant that identifies a "changed" item, i.e. an item with unread changes
+     * Read status constant that identifies a "changed" item, i.e. an item with unread changes.
      * @var string
      */
     public const READ_STATUS_CHANGED = 'changed';
 
+    // TODO: most CommSy code currently uses an empty string ('') instead of READ_STATUS_SEEN/'seen'
     /**
-     * Read status constant that identifies a "seen" item, i.e. an item that has been read before
+     * Read status constant that identifies a "seen" item, i.e. an item that has been read before.
      * @var string
      */
     public const READ_STATUS_SEEN = 'seen';
 
     /**
-     * Read status constant that identifies an item that has a "new annotation" which hasn't been seen before
+     * Read status constant that identifies an item that has a "new annotation" which hasn't been seen before.
      * @var string
      */
     public const READ_STATUS_NEW_ANNOTATION = 'new_annotation';
 
     /**
-     * Read status constant that identifies an item that has a "changed annotation", i.e. an annotation with unread changes
+     * Read status constant that identifies an item that has a "changed annotation", i.e. an annotation with unread changes.
      * @var string
      */
     public const READ_STATUS_CHANGED_ANNOTATION = 'changed_annotation';

--- a/src/Utils/ReaderService.php
+++ b/src/Utils/ReaderService.php
@@ -224,7 +224,7 @@ class ReaderService
      * If there's no cached read status for the given item, this method calculates its read status and caches it.
      * The cached status will be invalidated:
      * - when the item gets saved (the `CommsyEditEvent::SAVE` will trigger `invalidateCachedReadStatusForItem()`)
-     * - when the item gets marked as read  (the `ReadStatusWillChangeEvent` will trigger `invalidateCachedReadStatusForItem()`)
+     * - when the item gets marked as read  (the `ReadStatusPreChangeEvent` will trigger `invalidateCachedReadStatusForItem()`)
      * - or, otherwise, after 12 hours
      * @param \cs_item $item the item whose cached read status shall be returned
      * @param \cs_user_item $user the user whose read status shall be used (defaults to the current user if not given)

--- a/src/Utils/ReaderService.php
+++ b/src/Utils/ReaderService.php
@@ -67,9 +67,13 @@ class ReaderService
     {
         $return = '';
 
+        $item = $this->itemService->getTypedItem($itemId);
+        if (!$item) {
+            return $return;
+        }
+
         $readerManager = $this->readerManager;
         $reader = $readerManager->getLatestReaderForUserByID($itemId, $userID);
-        $item = $this->itemService->getTypedItem($itemId);
         if (empty($reader)) {
             $currentUser = $this->legacyEnvironment->getEnvironment()->getCurrentUserItem();
             $itemIsCurrentUser = ($item instanceof \cs_user_item && $item->getUserID() === $currentUser->getUserID());

--- a/src/Utils/ReaderService.php
+++ b/src/Utils/ReaderService.php
@@ -184,7 +184,7 @@ class ReaderService
 
     /**
      * Returns the IDs of all items among the given items matching the given read status (for the given user).
-     * Note that this method will also return IDs for items with new/changed annotations if "new"/"changed" has been
+     * Note that this method will also return IDs for items with new/changed annotations if "changed" has been
      * specified as read status.
      * @param \cs_item[] $items array of items from which IDs for all items matching `$readStatus` shall be returned
      * @param string $readStatus the read status for which IDs of matching items shall be returned
@@ -205,10 +205,11 @@ class ReaderService
                 $cachedReadStatus = $this->cachedReadStatusForItem($item, $user);
 
                 // NOTE: instead of READ_STATUS_SEEN, getChangeStatusForUserByID() currently returns an empty string ('');
-                // also, we treat READ_STATUS_NEW_ANNOTATION like READ_STATUS_NEW, and READ_STATUS_CHANGED_ANNOTATION
-                // like READ_STATUS_CHANGED
-                if ($cachedReadStatus === '' && $readStatus === ReaderService::READ_STATUS_SEEN
-                    || strpos($cachedReadStatus, $readStatus) === 0) {
+                // also, we treat READ_STATUS_NEW_ANNOTATION and READ_STATUS_CHANGED_ANNOTATION like READ_STATUS_CHANGED
+                if ($cachedReadStatus === $readStatus
+                    || $cachedReadStatus === '' && $readStatus === self::READ_STATUS_SEEN
+                    || $cachedReadStatus === self::READ_STATUS_NEW_ANNOTATION && $readStatus === self::READ_STATUS_CHANGED
+                    || $cachedReadStatus === self::READ_STATUS_CHANGED_ANNOTATION && $readStatus === self::READ_STATUS_CHANGED) {
                     $itemId = $item->getItemId();
                     $itemIds[] = $itemId;
                 }

--- a/src/Utils/ReaderService.php
+++ b/src/Utils/ReaderService.php
@@ -7,6 +7,36 @@ use App\Utils\ItemService;
 
 class ReaderService
 {
+    /**
+     * Read status constant that identifies a "new" item, i.e. an item that hasn't been seen before
+     * @var string
+     */
+    public const READ_STATUS_NEW = 'new';
+
+    /**
+     * Read status constant that identifies a "changed" item, i.e. an item with unread changes
+     * @var string
+     */
+    public const READ_STATUS_CHANGED = 'changed';
+
+    /**
+     * Read status constant that identifies a "seen" item, i.e. an item that has been read before
+     * @var string
+     */
+    public const READ_STATUS_SEEN = 'seen';
+
+    /**
+     * Read status constant that identifies an item that has a "new annotation" which hasn't been seen before
+     * @var string
+     */
+    public const READ_STATUS_NEW_ANNOTATION = 'new_annotation';
+
+    /**
+     * Read status constant that identifies an item that has a "changed annotation", i.e. an annotation with unread changes
+     * @var string
+     */
+    public const READ_STATUS_CHANGED_ANNOTATION = 'changed_annotation';
+
     private $legacyEnvironment;
     private $readerManager;
     private $itemService;
@@ -44,10 +74,10 @@ class ReaderService
             $currentUser = $this->legacyEnvironment->getEnvironment()->getCurrentUserItem();
             $itemIsCurrentUser = ($item instanceof \cs_user_item && $item->getUserID() === $currentUser->getUserID());
             if (!$itemIsCurrentUser) {
-                $return = 'new';
+                $return = self::READ_STATUS_NEW;
             }
         } else if (!$item->isNotActivated() and $reader['read_date'] < $item->getModificationDate()) {
-            $return = 'changed';
+            $return = self::READ_STATUS_CHANGED;
         }
 
         if ($return == '') {
@@ -77,9 +107,9 @@ class ReaderService
             }
 
             if ($new) {
-                $return = 'new_annotation';
+                $return = self::READ_STATUS_NEW_ANNOTATION;
             } else if ($changed) {
-                $return = 'changed_annotation';
+                $return = self::READ_STATUS_CHANGED_ANNOTATION;
             }
         }
 
@@ -127,9 +157,9 @@ class ReaderService
             }
 
             if ($new) {
-                $return = 'changed';
+                $return = self::READ_STATUS_CHANGED;
             } else if ($changed) {
-                $return = 'changed';
+                $return = self::READ_STATUS_CHANGED;
             }
         }
 

--- a/templates/search/feed.html.twig
+++ b/templates/search/feed.html.twig
@@ -7,6 +7,25 @@
 
         <header class="uk-comment-header uk-flex">
 
+            {# change status (aka read status) #}
+            {% if result.readStatus is same as('new') %}
+                <div class="cs-comment-change-info" data-uk-tooltip="{pos:'right'}" title="{{ 'newEntry'|trans({}) }}">
+                    <i class="uk-icon-medium uk-text-danger uk-icon-exclamation"></i>
+                </div>
+            {% elseif result.readStatus is same as('changed') %}
+                <div class="cs-comment-change-info" data-uk-tooltip="{pos:'right'}" title="{{ 'changedEntry'|trans({})}}">
+                    <i class="uk-icon-medium uk-text-warning uk-icon-exclamation"></i>
+                </div>
+            {% elseif result.readStatus is same as('new_annotation') %}
+                <div class="cs-comment-change-info" data-uk-tooltip="{pos:'right'}" title="{{ 'newAnnotation'|trans({})}}">
+                    <i class="uk-icon-medium uk-text-warning uk-icon-exclamation"></i>
+                </div>
+            {% elseif result.readStatus is same as('changed_annotation') %}
+                <div class="cs-comment-change-info" data-uk-tooltip="{pos:'right'}" title="{{ 'changedAnnotation'|trans({})}}">
+                    <i class="uk-icon-medium uk-text-warning uk-icon-exclamation"></i>
+                </div>
+            {% endif %}
+
             <div class="items-checkbox uk-margin-right uk-margin-top uk-hidden">
                 <form class="uk-form">
                     <input type="checkbox" value="{{ entity.itemId }}">

--- a/templates/search/results.html.twig
+++ b/templates/search/results.html.twig
@@ -71,6 +71,7 @@
                                                         'search_filter[phrase]': searchData.phrase,
                                                         'search_filter[appears_in][0]': searchData.appearsInTitle ? 'title' : '',
                                                         "search_filter[appears_in][1]": searchData.appearsInDescription ? 'description' : '',
+                                                        "search_filter[selectedReadStatus]": searchData.selectedReadStatus,
                                                         "search_filter[selectedCreator]": searchData.selectedCreator,
                                                         "search_filter[selectedContext]": searchData.selectedContext,
                                                         "search_filter[creation_date_range][left_date]": searchData.creationDateFrom ? searchData.creationDateFrom.format('d.m.Y') : '',
@@ -153,6 +154,7 @@
                                     "search[phrase]": "{{ searchData.phrase }}",
                                     "search[appears_in][]": "{{ searchData.appearsInTitle ? 'title' : '' }}",
                                     "search[appears_in][]": "{{ searchData.appearsInDescription ? 'description' : '' }}",
+                                    "search[selectedReadStatus]": "{{ searchData.selectedReadStatus }}",
                                     "search[selectedCreator]": "{{ searchData.selectedCreator }}",
                                     "search[selectedContext]": "{{ searchData.selectedContext }}",
                                     {% for hashtag in searchData.selectedHashtags -%}

--- a/translations/search.de.xlf
+++ b/translations/search.de.xlf
@@ -90,6 +90,22 @@
                 <source>Groups, Topics and Institutions</source>
                 <target>Gruppen, Themen &amp; Institutionen</target>
             </trans-unit>
+            <trans-unit id="search-filter-read-status">
+                <source>Read status</source>
+                <target>Gelesen-Status</target>
+            </trans-unit>
+            <trans-unit id="search-filter-read-status-new">
+                <source>New</source>
+                <target>Neu</target>
+            </trans-unit>
+            <trans-unit id="search-filter-read-status-modified">
+                <source>Modified</source>
+                <target>Geändert</target>
+            </trans-unit>
+            <trans-unit id="search-filter-read-status-read">
+                <source>Read</source>
+                <target>Gelesen</target>
+            </trans-unit>
             <trans-unit id="room-search">
                 <source>Room search</source>
                 <target>Raumsuche</target>

--- a/translations/search.en.xlf
+++ b/translations/search.en.xlf
@@ -90,6 +90,22 @@
                 <source>Groups, Topics and Institutions</source>
                 <target>Groups, Topics &amp; Institutions</target>
             </trans-unit>
+            <trans-unit id="search-filter-read-status">
+                <source>Read status</source>
+                <target>Read status</target>
+            </trans-unit>
+            <trans-unit id="search-filter-read-status-new">
+                <source>New</source>
+                <target>New</target>
+            </trans-unit>
+            <trans-unit id="search-filter-read-status-modified">
+                <source>Modified</source>
+                <target>Modified</target>
+            </trans-unit>
+            <trans-unit id="search-filter-read-status-read">
+                <source>Read</source>
+                <target>Read</target>
+            </trans-unit>
             <trans-unit id="room-search">
                 <source>Room search</source>
                 <target>Workspace search</target>


### PR DESCRIPTION
PR for [#3787](https://projects.effective-webwork.de/projects/commsy/work_packages/3787) which enables filtering by read status (all, new only, modified only, read only).

The read status for the user's searchable items gets cached so that it doesn't need to be computed again every time.

Also, the read status (new/changed) now gets displayed as an exclamation mark icon next to each search result.

Note that (for testing/debugging purposes) my branch for #3787 (`feature/ms-3787-readfilter`) is based on the `feature/3748_2` branch, so this PR is against that branch (so that it only displays my new commits). I don't intend to perform the actual merge with this PR. It's just to gather review feedback.