### PR TITLE
Fixes #3035: issues when printing or saving an item with a description containing image(s)

### DIFF
--- a/templates/base/printmacro.html.twig
+++ b/templates/base/printmacro.html.twig
@@ -308,7 +308,7 @@
 
                 {# preview #}
                 <div>
-                    {{ content|raw }}
+                    {{ content|commsyMarkup(item)|raw }}
                 </div>
 
             </div>


### PR DESCRIPTION
This PR fixes a wkhtml exception when printing an item with a description containing image(s). It also fixes a similar exception when saving this item as a .zip file.

Background: wkhtml (which gets used to generate the print PDFs) couldn't find any images included by the CKEditor since their paths were root-relative and not absolute