### PR TITLE
4249: Viewing details of a portfolio entry does not lead to a new tab…

### DIFF
--- a/src/Controller/AnnotationController.php
+++ b/src/Controller/AnnotationController.php
@@ -238,7 +238,15 @@ class AnnotationController extends AbstractController
 
                 return $this->redirectToRoute('app_'.$itemType.'_detail', $routeArray);
             }
+            if ($form->get('cancel')->isClicked()) {
+                if ($itemType == 'portfolio') {
+                    return $this->redirectToRoute('app_portfolio_index', [
+                        'roomId' => $roomId,
+                    ]);
+                }
+            }
         }
+
         return $this->redirectToRoute('app_'.$itemType.'_detail', array('roomId' => $roomId, 'itemId' => $itemId));
     }
 

--- a/src/Form/Type/AnnotationType.php
+++ b/src/Form/Type/AnnotationType.php
@@ -45,7 +45,7 @@ class AnnotationType extends AbstractType
                 'attr' => array(
                     'formnovalidate' => 'formnovalidate',
                 ),
-                'label' => 'cancel',
+                'label' => 'Back',
                 'validation_groups' => 'false',
             ))
         ;

--- a/templates/portfolio/portfolio.html.twig
+++ b/templates/portfolio/portfolio.html.twig
@@ -106,9 +106,9 @@
                                         </div>
                                         <h3 class="uk-panel-title uk-text-right">
                                             {% if foundContent %}
-                                                <a href="{{ path('app_portfolio_detail', {'roomId': roomId, 'portfolioId': portfolioId, 'firstTagId': firstTagId, 'secondTagId': secondTagId}) }}" data-uk-tooltip target="_blank" title="{{ 'Details'|trans({}, 'portfolio') }}"><i class="uk-icon-list"></i></a>
+                                                <a href="{{ path('app_portfolio_detail', {'roomId': roomId, 'portfolioId': portfolioId, 'firstTagId': firstTagId, 'secondTagId': secondTagId}) }}" data-uk-tooltip title="{{ 'Details'|trans({}, 'portfolio') }}"><i class="uk-icon-list"></i></a>
                                             {% else %}
-                                                <a href="{{ path('app_portfolio_detail', {'roomId': roomId, 'portfolioId': portfolioId, 'firstTagId': firstTag.t_id, 'secondTagId': secondTag.t_id}) }}" data-uk-tooltip target="_blank" title="{{ 'Details'|trans({}, 'portfolio') }}"><i class="uk-icon-list"></i></a>
+                                                <a href="{{ path('app_portfolio_detail', {'roomId': roomId, 'portfolioId': portfolioId, 'firstTagId': firstTag.t_id, 'secondTagId': secondTag.t_id}) }}" data-uk-tooltip title="{{ 'Details'|trans({}, 'portfolio') }}"><i class="uk-icon-list"></i></a>
                                             {% endif %}
                                         </h3>
                                         {% if foundContent %}

--- a/translations/form.de.xlf
+++ b/translations/form.de.xlf
@@ -6,6 +6,10 @@
                 <source>Add</source>
                 <target>Hinzufügen</target>
             </trans-unit>
+            <trans-unit id="form-back">
+                <source>Back</source>
+                <target>Zurück</target>
+            </trans-unit>
             <trans-unit id="form-filter">
                 <source>Filter</source>
                 <target>Filtern</target>

--- a/translations/form.en.xlf
+++ b/translations/form.en.xlf
@@ -6,6 +6,10 @@
                 <source>Add</source>
                 <target>Add</target>
             </trans-unit>
+            <trans-unit id="form-back">
+                <source>Back</source>
+                <target>Back</target>
+            </trans-unit>
             <trans-unit id="form-filter">
                 <source>Filter</source>
                 <target>Filter</target>


### PR DESCRIPTION
… and the cancel button (re-labeled: 'back') now leads back to the portfolio index.