### PR TITLE
#4296: when a locked user attempts to login an appropriate error mess…

### DIFF
--- a/src/Exception/AccountLockedException.php
+++ b/src/Exception/AccountLockedException.php
@@ -4,9 +4,9 @@
 namespace App\Exception;
 
 
-use Symfony\Component\Security\Core\Exception\AccountStatusException;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 
-class AccountLockedException extends AccountStatusException
+class AccountLockedException extends CustomUserMessageAuthenticationException
 {
 
 }

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -26,7 +26,7 @@ class UserChecker implements UserCheckerInterface
 
         /** @var $user Account */
         if ($user->isLocked()) {
-            throw new AccountLockedException('Account is locked');
+            throw new AccountLockedException('Account is locked.');
         }
     }
 }

--- a/translations/security.de.xlf
+++ b/translations/security.de.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="de" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="login_authentication_checkcredentials_exception">
+                <source>Invalid credentials.</source>
+                <target>Ungültige Login-Daten.</target>
+            </trans-unit>
+            <trans-unit id="login_authentication_getuser_exception">
+                <source>A problem with your account occurred.</source>
+                <target>Es ist ein Problem mit Ihrer Kennung aufgetreten.</target>
+            </trans-unit>
+            <trans-unit id="login_authentication_userchecker_exception">
+                <source>Account is locked.</source>
+                <target>Diese Kennung ist gesperrt.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/security.en.xlf
+++ b/translations/security.en.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="login_authentication_checkcredentials_exception">
+                <source>Invalid credentials.</source>
+                <target>Invalid credentials.</target>
+            </trans-unit>
+            <trans-unit id="login_authentication_getuser_exception">
+                <source>A problem with your account occurred.</source>
+                <target>A problem with your account occurred.</target>
+            </trans-unit>
+            <trans-unit id="login_authentication_userchecker_exception">
+                <source>Account is locked.</source>
+                <target>Account is locked.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
…age is now displayed ("Account is locked.")

this also adds translations for other common account-related exceptions