### PR TITLE
#4251: in a room with mandatory assignment of categories and/or hasht…

### DIFF
--- a/src/Controller/AnnouncementController.php
+++ b/src/Controller/AnnouncementController.php
@@ -639,7 +639,9 @@ class AnnouncementController extends BaseController
                         $categoryIds[] = $newCategory->getItemID();
                     }
 
-                    $announcementItem->setTagListByID($categoryIds);
+                    if (!empty($categoryIds)) {
+                        $announcementItem->setTagListByID($categoryIds);
+                    }
                 }
                 if ($hashtagsMandatory) {
                     $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
@@ -650,7 +652,9 @@ class AnnouncementController extends BaseController
                         $hashtagIds[] = $newHashtag->getItemID();
                     }
 
-                    $announcementItem->setBuzzwordListByID($hashtagIds);
+                    if (!empty($hashtagIds)) {
+                        $announcementItem->setBuzzwordListByID($hashtagIds);
+                    }
                 }
 
                 $announcementItem->save();

--- a/src/Controller/DateController.php
+++ b/src/Controller/DateController.php
@@ -1114,7 +1114,7 @@ class DateController extends BaseController
             'calendarsAttr' => $calendarsOptionsAttr,
             'categoryMappingOptions' => [
                 'categories' => $itemController->getCategories($roomId, $categoryService),
- 'categoryPlaceholderText' => $this->translator->trans('New category', [], 'category'),
+                'categoryPlaceholderText' => $this->translator->trans('New category', [], 'category'),
                 'categoryEditUrl' => $this->generateUrl('app_category_add', ['roomId' => $roomId])
             ],
             'hashtagMappingOptions' => [
@@ -1156,7 +1156,9 @@ class DateController extends BaseController
                         $categoryIds[] = $newCategory->getItemID();
                     }
 
-                    $dateItem->setTagListByID($categoryIds);
+                    if (!empty($categoryIds)) {
+                        $dateItem->setTagListByID($categoryIds);
+                    }
                 }
                 if ($hashtagsMandatory) {
                     $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
@@ -1167,7 +1169,9 @@ class DateController extends BaseController
                         $hashtagIds[] = $newHashtag->getItemID();
                     }
 
-                    $dateItem->setBuzzwordListByID($hashtagIds);
+                    if (!empty($hashtagIds)) {
+                        $dateItem->setBuzzwordListByID($hashtagIds);
+                    }
                 }
 
                 $valuesToChange = array();

--- a/src/Controller/DiscussionController.php
+++ b/src/Controller/DiscussionController.php
@@ -919,17 +919,21 @@ class DiscussionController extends BaseController
                             $categoryIds[] = $newCategory->getItemID();
                         }
 
-                        $discussionItem->setTagListByID($categoryIds);
+                        if (!empty($categoryIds)) {
+                            $discussionItem->setTagListByID($categoryIds);
+                        }
                     }
                     if ($hashtagsMandatory) {
                         $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
-    if (isset($formData['hashtag_mapping']['newHashtag'])) {
+                        if (isset($formData['hashtag_mapping']['newHashtag'])) {
                             $newHashtagTitle = $formData['hashtag_mapping']['newHashtag'];
                             $newHashtag = $labelService->getNewHashtag($newHashtagTitle, $roomId);
                             $hashtagIds[] = $newHashtag->getItemID();
                         }
 
-                        $discussionItem->setBuzzwordListByID($hashtagIds);
+                        if (!empty($hashtagIds)) {
+                            $discussionItem->setBuzzwordListByID($hashtagIds);
+                        }
                     }
 
                     $discussionItem->save();

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -804,7 +804,9 @@ class GroupController extends BaseController
                         $categoryIds[] = $newCategory->getItemID();
                     }
 
-                    $groupItem->setTagListByID($categoryIds);
+                    if (!empty($categoryIds)) {
+                        $groupItem->setTagListByID($categoryIds);
+                    }
                 }
                 if ($hashtagsMandatory) {
                     $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
@@ -815,7 +817,9 @@ class GroupController extends BaseController
                         $hashtagIds[] = $newHashtag->getItemID();
                     }
 
-                    $groupItem->setBuzzwordListByID($hashtagIds);
+                    if (!empty($hashtagIds)) {
+                        $groupItem->setBuzzwordListByID($hashtagIds);
+                    }
                 }
 
                 $groupItem->save();

--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -1063,8 +1063,8 @@ class MaterialController extends BaseController
             $formData = $this->materialTransformer->transform($materialItem);
             $formData['categoriesMandatory'] = $categoriesMandatory;
             $formData['hashtagsMandatory'] = $hashtagsMandatory;
-            $formData['hashtag_mapping']['categories'] = $itemController->getLinkedCategories($item);
-            $formData['category_mapping']['hashtags'] = $itemController->getLinkedHashtags($itemId, $roomId,
+            $formData['category_mapping']['categories'] = $itemController->getLinkedCategories($item);
+            $formData['hashtag_mapping']['hashtags'] = $itemController->getLinkedHashtags($itemId, $roomId,
                 $this->legacyEnvironment);
 
             $licensesRepository = $this->getDoctrine()->getRepository(License::class);
@@ -1132,7 +1132,9 @@ class MaterialController extends BaseController
                         $categoryIds[] = $newCategory->getItemID();
                     }
 
-                    $typedItem->setTagListByID($categoryIds);
+                    if (!empty($categoryIds)) {
+                        $typedItem->setTagListByID($categoryIds);
+                    }
                 }
                 if ($hashtagsMandatory) {
                     $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
@@ -1147,7 +1149,9 @@ class MaterialController extends BaseController
 
                     }
 
-                    $typedItem->setBuzzwordListByID($hashtagIds);
+                    if (!empty($hashtagIds)) {
+                        $typedItem->setBuzzwordListByID($hashtagIds);
+                    }
                 }
 
                 $typedItem->save();

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -654,7 +654,9 @@ class TodoController extends BaseController
                         $categoryIds[] = $newCategory->getItemID();
                     }
 
-                    $todoItem->setTagListByID($categoryIds);
+                    if (!empty($categoryIds)) {
+                        $todoItem->setTagListByID($categoryIds);
+                    }
                 }
                 if ($hashtagsMandatory) {
                     $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
@@ -665,7 +667,9 @@ class TodoController extends BaseController
                         $hashtagIds[] = $newHashtag->getItemID();
                     }
 
-                    $todoItem->setBuzzwordListByID($hashtagIds);
+                    if (!empty($hashtagIds)) {
+                        $todoItem->setBuzzwordListByID($hashtagIds);
+                    }
                 }
 
                 $todoItem->save();

--- a/src/Controller/TopicController.php
+++ b/src/Controller/TopicController.php
@@ -521,7 +521,9 @@ class TopicController extends BaseController
                         $categoryIds[] = $newCategory->getItemID();
                     }
 
-                    $topicItem->setTagListByID($categoryIds);
+                    if (!empty($categoryIds)) {
+                        $topicItem->setTagListByID($categoryIds);
+                    }
                 }
                 if ($hashtagsMandatory) {
                     $hashtagIds = $formData['hashtag_mapping']['hashtags'] ?? [];
@@ -532,7 +534,9 @@ class TopicController extends BaseController
                         $hashtagIds[] = $newHashtag->getItemID();
                     }
 
-                    $topicItem->setBuzzwordListByID($hashtagIds);
+                    if (!empty($hashtagIds)) {
+                        $topicItem->setBuzzwordListByID($hashtagIds);
+                    }
                 }
 
                 $topicItem->save();


### PR DESCRIPTION
…ags, editing the title of a material item now won't cause any assigned categories and/or hashtags to get lost