### PR TITLE
Change for bug 4505, Resolve BUG - Sending a date via mail

### DIFF
--- a/src/Form/Type/SendType.php
+++ b/src/Form/Type/SendType.php
@@ -86,6 +86,7 @@ class SendType extends AbstractType
                                 'translation_domain' => 'mail',
                                 'choice_translation_domain' => 'form',
                                 'required' => true,
+                                'data' => false,
                             ])
                         ;
                     }

--- a/translations/mail.de.xlf
+++ b/translations/mail.de.xlf
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="mailSendToAttendees">
                 <source>Send to attendees</source>
-                <target>An Teilnehmer versenden</target>
+                <target>An TeilnehmerInnen versenden</target>
             </trans-unit>
             <trans-unit id="mailSendToAssigned">
                 <source>Send to assigned</source>
@@ -60,11 +60,11 @@
             </trans-unit>
             <trans-unit id="mailAdditionalRecipients">
                 <source>Additional recipients</source>
-                <target>Zusätzliche Empfänger</target>
+                <target>Zusätzliche EmpfängerInnen</target>
             </trans-unit>
             <trans-unit id="mailAddRecipients">
                 <source>Add another recipient</source>
-                <target>Einen weiteren Empfänger hinzufügen</target>
+                <target>Weitere EmpfängerInnen hinzufügen</target>
             </trans-unit>
             <trans-unit id="mailAttachments">
                 <source>Attachments</source>


### PR DESCRIPTION
        - In the form at "send to attendees" should be the default choice "no" (similar to "send to creator").  - DONE
	- It should be "TeilnehmerInnen" and not "Teilnehmer".  - DONE
	- Below it should say "EmpfängerInnen" and not "Empfänger". - DONE
	- And it should be "Weitere EmpfängerInnen hinzufügen" instead of "Einen weiteren Empfänger hinzufügen".- DONE