### PR TITLE
Resolved bug 4504 - Modifier when importing a calendar

### DIFF
--- a/src/Services/CalendarsService.php
+++ b/src/Services/CalendarsService.php
@@ -361,7 +361,11 @@ class CalendarsService
                     if ($hasChanges || $hasChanges = ((int)$date->getModificatorID() !== $creatorId)) {
                         $date->setModifierID($creatorId);
                     }
-
+                    // Change for bug creator and Modifier set current user when insert new row .
+                    if ($hasChanges) {
+                        $date->setCreatorID($this->legacyEnvironment->getCurrentUserID());
+                        $date->setModifierID($this->legacyEnvironment->getCurrentUserID());
+                    }
                     if (!$hasChanges) {
                         // for existing date items, don't update their modification date if nothing has changed
                         $date->setChangeModificationOnSave(false);


### PR DESCRIPTION
The desired behavior is:
- The importer of the calendar/dates is set as the modifier of the date. 
- It should make no difference if the calendar already existed or is being created in the importing process.