### PR TITLE
Resolved bug - 4534 - 03 - Deactivated entries in the quick navigation

### DIFF
--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -1093,16 +1093,12 @@ class ItemController extends AbstractController
         if ($item->getItemType() == 'date') {
             $rubricManager->setWithoutDateModeLimit();
         }
-        
+        if(!$environment->getCurrentUserItem()->isModerator() ){
+            $rubricManager->setInactiveEntriesLimit(cs_manager::SHOW_ENTRIES_ONLY_ACTIVATED);
+        }
         $rubricManager->select();
         $itemList = $rubricManager->get();
         $items = $itemList->to_array();
-        foreach ($items as $key => $temp) {
-            if($temp->isNotActivated() and !$environment->getCurrentUserItem()->isModerator() ){
-               unset($items[$key]);
-            }
-        }
-        array_shift($items);
         $itemList = array();
         $counterBefore = 0;
         $counterAfter = 0;

--- a/src/Controller/ItemController.php
+++ b/src/Controller/ItemController.php
@@ -1097,7 +1097,12 @@ class ItemController extends AbstractController
         $rubricManager->select();
         $itemList = $rubricManager->get();
         $items = $itemList->to_array();
-        
+        foreach ($items as $key => $temp) {
+            if($temp->isNotActivated() and !$environment->getCurrentUserItem()->isModerator() ){
+               unset($items[$key]);
+            }
+        }
+        array_shift($items);
         $itemList = array();
         $counterBefore = 0;
         $counterAfter = 0;


### PR DESCRIPTION
Solution: To avoid the problem deactivated entries should not be listed in the quick navigation. And they therefore should also not be able to be reached by clicking on the arrows.