### PR TITLE
Resolved bug 4521 Upload in the CKEditor

### DIFF
--- a/public/ckeditor/commsyaudio/dialogs/dialog.js
+++ b/public/ckeditor/commsyaudio/dialogs/dialog.js
@@ -71,7 +71,7 @@
                                             id: 'upload',
                                             label: editor.lang.commsyaudio.uploadnew + '<br/>' + '<span style="font-size: 9px;color: red;">' + editor.lang.commsyaudio.uploadnewlegend + '</span>',
                                             onChange: function () {
-                                                const limit = 300000000;
+                                                const limit = editor.config.maxUploadSize;
                                                 var upload = this.getDialog().getContentElement('audioTab', 'upload');
                                                 var inputUpload = upload.getInputElement().$;
                                                 var sizeUpload = inputUpload.files[0]? inputUpload.files[0].size: 0;

--- a/public/ckeditor/commsyaudio/dialogs/dialog.js
+++ b/public/ckeditor/commsyaudio/dialogs/dialog.js
@@ -69,7 +69,21 @@
                                         {
                                             type: 'file',
                                             id: 'upload',
-                                            label: editor.lang.commsyaudio.uploadnew
+                                            label: editor.lang.commsyaudio.uploadnew + '<br/>' + '<span style="font-size: 9px;color: red;">' + editor.lang.commsyaudio.uploadnewlegend + '</span>',
+                                            onChange: function () {
+                                                const limit = 300000000;
+                                                var upload = this.getDialog().getContentElement('audioTab', 'upload');
+                                                var inputUpload = upload.getInputElement().$;
+                                                var sizeUpload = inputUpload.files[0]? inputUpload.files[0].size: 0;
+                                                if(sizeUpload === 0){
+                                                 return;
+                                                }                                                
+                                                if(sizeUpload >= limit){
+                                                	upload.setValue("");
+                                                	alert(editor.lang.commsyaudio.uploadnewfailed);                                                	
+                                                } 
+              
+                                            }
                                         },
                                         {
                                             type: 'fileButton',

--- a/public/ckeditor/commsyaudio/lang/de.js
+++ b/public/ckeditor/commsyaudio/lang/de.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.setLang('commsyaudio', 'de', {
     fileselect: 'Angehängte Datei auswählen',
     fileselectchoice: 'Auswahl',
     uploadnew: 'Neue Datei hochladen',
+    uploadnewlegend: 'Sie können Dateien bis zu 300 MB hochladen.',
+    uploadnewfailed: 'Upload fehlgeschlagen, bitte verwenden Sie eine kleinere Datei.',
     upload: 'Hochladen',
     url: 'Aus URL einfügen',
     emptyUrl: 'Bitte eine URL hinzufügen',

--- a/public/ckeditor/commsyaudio/lang/en.js
+++ b/public/ckeditor/commsyaudio/lang/en.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.setLang('commsyaudio', 'en', {
     fileselect: 'Select attached file',
     fileselectchoice: 'Select',
     uploadnew: 'Upload new file',
+    uploadnewlegend: 'Upload files up to 300 MB.',
+    uploadnewfailed: 'Upload failed, please upload a smaller file.',
     upload: 'Upload',
     url: 'From URL',
     emptyUrl: 'Please enter an URL',

--- a/public/ckeditor/commsyimage/dialogs/dialog.js
+++ b/public/ckeditor/commsyimage/dialogs/dialog.js
@@ -68,7 +68,21 @@
                                         {
                                             type: 'file',
                                             id: 'upload',
-                                            label: editor.lang.commsyimage.uploadnew,
+                                            label: editor.lang.commsyimage.uploadnew + '<br/>' + '<span style="font-size: 9px;color: red;">' + editor.lang.commsyimage.uploadnewlegend + '</span>',
+                                            onChange: function () {
+                                                const limit = 300000000;
+                                                var upload = this.getDialog().getContentElement('imageTab', 'upload');
+                                                var inputUpload = upload.getInputElement().$;
+                                                var sizeUpload = inputUpload.files[0]? inputUpload.files[0].size: 0;
+                                                if(sizeUpload === 0){
+                                                 return;
+                                                }                                                
+                                                if(sizeUpload >= limit){
+                                                	upload.setValue("");
+                                                	alert(editor.lang.commsyimage.uploadnewfailed);                                                	
+                                                } 
+              
+                                            }
                                         },
                                         {
                                             type: 'fileButton',

--- a/public/ckeditor/commsyimage/dialogs/dialog.js
+++ b/public/ckeditor/commsyimage/dialogs/dialog.js
@@ -70,7 +70,7 @@
                                             id: 'upload',
                                             label: editor.lang.commsyimage.uploadnew + '<br/>' + '<span style="font-size: 9px;color: red;">' + editor.lang.commsyimage.uploadnewlegend + '</span>',
                                             onChange: function () {
-                                                const limit = 300000000;
+                                                const limit = editor.config.maxUploadSize;
                                                 var upload = this.getDialog().getContentElement('imageTab', 'upload');
                                                 var inputUpload = upload.getInputElement().$;
                                                 var sizeUpload = inputUpload.files[0]? inputUpload.files[0].size: 0;

--- a/public/ckeditor/commsyimage/lang/de.js
+++ b/public/ckeditor/commsyimage/lang/de.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.setLang('commsyimage', 'de', {
     fileselect: 'Angehängte Datei auswählen',
     fileselectchoice: 'Auswahl',
     uploadnew: 'Neue Datei hochladen',
+    uploadnewlegend: 'Sie können Dateien bis zu 300 MB hochladen.',
+    uploadnewfailed: 'Upload fehlgeschlagen, bitte verwenden Sie eine kleinere Datei.',
     upload: 'Hochladen',
     url: 'Aus URL einfügen',
     emptyUrl: 'Bitte eine URL hinzufügen',

--- a/public/ckeditor/commsyimage/lang/en.js
+++ b/public/ckeditor/commsyimage/lang/en.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.setLang('commsyimage', 'en', {
     fileselect: 'Select attached file',
     fileselectchoice: 'Select',
     uploadnew: 'Upload new file',
+    uploadnewlegend: 'Upload files up to 300 MB.',
+    uploadnewfailed: 'Upload failed, please upload a smaller file.',
     upload: 'Upload',
     url: 'From URL',
     emptyUrl: 'Please enter an URL',

--- a/public/ckeditor/commsyvideo/dialogs/dialog.js
+++ b/public/ckeditor/commsyvideo/dialogs/dialog.js
@@ -98,7 +98,21 @@
                                         {
                                             type: 'file',
                                             id: 'upload',
-                                            label: editor.lang.commsyvideo.uploadnew
+                                            label: editor.lang.commsyvideo.uploadnew + '<br/>' + '<span style="font-size: 9px;color: red;">' + editor.lang.commsyvideo.uploadnewlegend + '</span>',
+                                            onChange: function () {
+                                                const limit = 300000000;
+                                                var upload = this.getDialog().getContentElement('videoTab', 'upload');
+                                                var inputUpload = upload.getInputElement().$;
+                                                var sizeUpload = inputUpload.files[0]? inputUpload.files[0].size: 0;
+                                                if(sizeUpload === 0){
+                                                 return;
+                                                }                                                
+                                                if(sizeUpload >= limit){
+                                                	upload.setValue("");
+                                                	alert(editor.lang.commsyvideo.uploadnewfailed);                                                	
+                                                } 
+              
+                                            }
                                         },
                                         {
                                             type: 'fileButton',

--- a/public/ckeditor/commsyvideo/dialogs/dialog.js
+++ b/public/ckeditor/commsyvideo/dialogs/dialog.js
@@ -100,7 +100,7 @@
                                             id: 'upload',
                                             label: editor.lang.commsyvideo.uploadnew + '<br/>' + '<span style="font-size: 9px;color: red;">' + editor.lang.commsyvideo.uploadnewlegend + '</span>',
                                             onChange: function () {
-                                                const limit = 300000000;
+                                                const limit = editor.config.maxUploadSize;
                                                 var upload = this.getDialog().getContentElement('videoTab', 'upload');
                                                 var inputUpload = upload.getInputElement().$;
                                                 var sizeUpload = inputUpload.files[0]? inputUpload.files[0].size: 0;

--- a/public/ckeditor/commsyvideo/lang/de.js
+++ b/public/ckeditor/commsyvideo/lang/de.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.setLang('commsyvideo', 'de', {
 	fileselect: 'Angehängte Datei auswählen',
     fileselectchoice: 'Auswahl',
 	uploadnew: 'Neue Datei hochladen',
+	uploadnewlegend: 'Sie können Dateien bis zu 300 MB hochladen.',
+	uploadnewfailed: 'Upload fehlgeschlagen, bitte verwenden Sie eine kleinere Datei.',
 	upload: 'Hochladen',
 	helpintro: 'Sie können Videos aus einer Vielzahl von Quellen wiedergeben, z.B.:',
 	helpdirect: 'Direkt: https://...',

--- a/public/ckeditor/commsyvideo/lang/en.js
+++ b/public/ckeditor/commsyvideo/lang/en.js
@@ -5,6 +5,8 @@ CKEDITOR.plugins.setLang('commsyvideo', 'en', {
     fileselect: 'Select attached file',
     fileselectchoice: 'Select',
     uploadnew: 'Upload new file',
+    uploadnewlegend: 'Upload files up to 300 MB.',
+    uploadnewfailed: 'Upload failed, please upload a smaller file.',
     upload: 'Upload',
     helpintro: 'You can provide various sources, e.g.',
     helpdirect: 'Direct: https://...',

--- a/src/Form/Type/ItemDescriptionType.php
+++ b/src/Form/Type/ItemDescriptionType.php
@@ -39,6 +39,7 @@ class ItemDescriptionType extends AbstractType
                     // as its default upload method; see https://ckeditor.com/docs/ckeditor4/latest/guide/dev_file_browser_api.html
                     'filebrowserUploadMethod' => 'form',
                     'filebrowserUploadUrl' => $options['uploadUrl'],
+                    'maxUploadSize' => $this->getConfigValueInBytes('upload_max_filesize'),
                 ],
                 'translation_domain' => 'material',
                 'required' => false,
@@ -109,5 +110,35 @@ class ItemDescriptionType extends AbstractType
     public function getBlockPrefix()
     {
         return 'itemDescription';
+    }
+
+    /**
+     * For a PHP configuration key whose value describes a size in (kilo/mega)bytes, returns the value in bytes.
+     * Returns 0.0 on failure.
+     * @param string $configName The PHP configuration key whose size value shall be retrieved via `ini_get`.
+     * Note that the value must resolve to a number or a number followed by a one-letter suffix (like "1k" or "2M").
+     * @return float
+     */
+    private function getConfigValueInBytes(string $configName): float
+    {
+        $value = ini_get($configName);
+        if (empty($value)) {
+            return 0.0;
+        }
+
+        // if necessary, convert to a number in bytes
+        $value = trim($value);
+        $suffix = strtolower($value[strlen($value) - 1]);
+        $value = intval($value);
+        switch ($suffix) {
+            case 'k':
+                $value *= 1024;
+                break;
+            case 'm':
+                $value *= 1048576;
+                break;
+        }
+
+        return $value;
     }
 }


### PR DESCRIPTION
In the CKEditor should be the upload limit just like in the files part of an entry should an upload limit be shown. Like this: 
English: Upload files up to 300 MB. 
German: Sie können Dateien bis zu 300 MB hochladen

The current error in the CKEditor for a file that is too large is not usability friendly. If a file is to big, there should be an error message, like this: 

English: Upload failed, please upload a smaller file.

German: Upload fehlgeschlagen, bitte verwenden Sie eine kleinere Datei.

