### PR TITLE
Teamq/4509 - Room detail page: last modifier

### DIFF
--- a/templates/project/macros.html.twig
+++ b/templates/project/macros.html.twig
@@ -31,31 +31,6 @@
             <div class="uk-width-1-1 uk-padding-remove uk-margin-small-bottom">
                 <div class="uk-grid uk-margin-small-left uk-margin-top-remove">
                     <div class="uk-width-9-10 uk-padding-remove">
-                        <div class="toggle-title-{{ item.itemId }}">
-                            <div class="uk-panel">
-                                <div class="uk-grid">
-                                    <div class="uk-width-1-1">
-                                        <div class="uk-flex">
-                                            <div class="uk-margin-right">
-                                                {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
-                                                    {{ macros.userIconLink(item.modificatorItem) }}
-                                                {% else %}
-                                                    {{ macros.userIcon(item.modificatorItem) }}
-                                                {% endif %}
-                                            </div>
-                                            <div class="uk-margin-right">
-                                                {% if '9999-00-00' not in item.getModificationDate %}
-                                                    {{ 'last changed'|trans({})|capitalize }}: {{ item.modificationDate|craue_date }} {{ item.modificationDate|craue_time }}<br/>
-                                                {% else %}
-                                                    {{ 'last changed'|trans({})|capitalize }}: {{ item.creationDate|craue_date }} {{ item.creationDate|craue_time }}<br/>
-                                                {% endif %}
-                                                {{ 'changed by'|trans({})|capitalize }}: {{ macros.userFullname(item.modificatorItem) }}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="toggle-title-{{ item.itemId }} uk-hidden">
                             <div class="uk-panel">
                                 <div class="uk-grid">

--- a/templates/room/macros.html.twig
+++ b/templates/room/macros.html.twig
@@ -165,7 +165,6 @@
                                 <div class="uk-width-1-1">
                                     <div class="uk-flex">
                                         <div class="uk-margin-right">
-                                            bbbbbbbbbbbbbbbbbbbbb
                                             {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
                                                 {{ macros.userIconLink(item.modificatorItem) }}
                                             {% else %}
@@ -187,7 +186,6 @@
                                 <div class="uk-width-2-5">
                                     <div class="uk-flex">
                                         <div class="uk-margin-right">
-                                            aaaaaaaaaaaaaaaaaaaaaaaaaa
                                             {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
                                                 {{ macros.userIconLink(item.modificatorItem) }}
                                             {% else %}

--- a/templates/room/macros.html.twig
+++ b/templates/room/macros.html.twig
@@ -34,31 +34,6 @@
             <div class="uk-width-1-1 uk-padding-remove uk-margin-small-bottom">
                 <div class="uk-grid uk-margin-small-left uk-margin-top-remove">
                     <div class="uk-width-9-10 uk-padding-remove">
-                        <div class="toggle-title-{{ item.itemId }}">
-                            <div class="uk-panel">
-                                <div class="uk-grid">
-                                    <div class="uk-width-1-1">
-                                        <div class="uk-flex">
-                                            <div class="uk-margin-right">
-                                                {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
-                                                    {{ macros.userIconLink(item.modificatorItem) }}
-                                                {% else %}
-                                                    {{ macros.userIcon(item.modificatorItem) }}
-                                                {% endif %}
-                                            </div>
-                                            <div class="uk-margin-right">
-                                                {% if '9999-00-00' not in item.getModificationDate %}
-                                                    {{ 'last changed'|trans({})|capitalize }}: {{ item.modificationDate|craue_date }} {{ item.modificationDate|craue_time }}<br/>
-                                                {% else %}
-                                                    {{ 'last changed'|trans({})|capitalize }}: {{ item.creationDate|craue_date }} {{ item.creationDate|craue_time }}<br/>
-                                                {% endif %}
-                                                {{ 'changed by'|trans({})|capitalize }}: {{ macros.userFullname(item.modificatorItem) }}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="toggle-title-{{ item.itemId }} uk-hidden">
                             <div class="uk-panel">
                                 <div class="uk-grid">
@@ -190,6 +165,7 @@
                                 <div class="uk-width-1-1">
                                     <div class="uk-flex">
                                         <div class="uk-margin-right">
+                                            bbbbbbbbbbbbbbbbbbbbb
                                             {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
                                                 {{ macros.userIconLink(item.modificatorItem) }}
                                             {% else %}
@@ -211,6 +187,7 @@
                                 <div class="uk-width-2-5">
                                     <div class="uk-flex">
                                         <div class="uk-margin-right">
+                                            aaaaaaaaaaaaaaaaaaaaaaaaaa
                                             {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
                                                 {{ macros.userIconLink(item.modificatorItem) }}
                                             {% else %}


### PR DESCRIPTION
When someone requests to become a new member in a room, this user will be shown as the last modifier on the room detail page. 
This makes technically sense but can be misleading for users. Therefore the icon and fields "last changed" and "changed by" should be removed for rooms.

