### PR TITLE
Resolved bug 4511 - Template settings for community workspaces

### DIFF
--- a/legacy/classes/cs_context_item.php
+++ b/legacy/classes/cs_context_item.php
@@ -1362,6 +1362,24 @@ class cs_context_item extends cs_item {
     }
     return $retour;
   }
+  /**
+   * Return value for Room asociation
+   * @return mixed|string|void
+   */
+  function _getRoomAssociation () {
+    $retour = '';
+    if ($this->_issetExtra('ROOMASSOCIATION')) {
+      $retour = $this->_getExtra('ROOMASSOCIATION');
+    }
+    return $retour;
+  }
+
+  /*
+   * set value to room asociation
+   */
+  public function _setRoomAssociation ( $value ) {
+    $this->_addExtra('ROOMASSOCIATION',$value);
+  }
 
   /** set flag for check new members
    * this method sets the flag for checking new members

--- a/src/Room/Copy/LegacyCopy.php
+++ b/src/Room/Copy/LegacyCopy.php
@@ -85,6 +85,10 @@ class LegacyCopy implements CopyStrategy
         $copy_array['rss'] = true;
         $copy_array['language'] = true;
         $copy_array['visibilitydefaults'] = true;
+        $copy_array['checknewmembers'] = true;
+        $copy_array['checknewmembers_code'] = true;
+        $copy_array['roomassociation'] = true;
+
 
         // now adaption for special rooms
         if ($source->isProjectRoom()) {
@@ -219,6 +223,16 @@ class LegacyCopy implements CopyStrategy
         if ($copy_array['htmltextareastatus']) {
             $target->setHtmlTextAreaStatus($source->getHtmlTextAreaStatus());
         }
+        if ($copy_array['checknewmembers']) {
+            $target->_setCheckNewMember($source->_getCheckNewMembers());
+        }
+        if ($copy_array['checknewmembers_code']) {
+            $target->setCheckNewMemberCode($source->getCheckNewMemberCode());
+        }
+        if ($copy_array['roomassociation']) {
+            $target->_setRoomAssociation($source->_getRoomAssociation());
+        }
+
         // config of buzzwords
         if ($copy_array['buzzword']) {
             if ($source->isBuzzwordMandatory()) {


### PR DESCRIPTION
These settings of the template should be also adopted: 

The setting for "Only members are allow to assign project workspaces" that can be set in the general workspace settings 
The setting for "Access check" (Deactivate, Always or Code) that can be set in the general workspace settings 