### PR TITLE
Teamq/4628 On user detail page "related groups" are shown when groups are off in the room

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -789,6 +789,13 @@ class UserController extends BaseController
                 $lastItemId = $users[sizeof($users) - 1]->getItemId();
             }
         }
+        $groups = [];
+        $context_item = $this->legacyEnvironment->getCurrentContextItem();
+        $conf = $context_item->getHomeConf();
+        if(strpos($conf, "group_show") == true) {
+            $groups = $this->userService->getUser($itemId)->getGroupList()->to_array();
+        }
+
 
         $infoArray['user'] = $user;
         $infoArray['readerList'] = $readerList;
@@ -809,7 +816,7 @@ class UserController extends BaseController
         $infoArray['currentUser'] = $this->legacyEnvironment->getCurrentUserItem();
         $infoArray['showCategories'] = $current_context->withTags();
         $infoArray['showHashtags'] = $current_context->withBuzzwords();
-        $infoArray['linkedGroups'] = $this->userService->getUser($itemId)->getGroupList()->to_array();;
+        $infoArray['linkedGroups'] = $groups;
         $infoArray['comment'] = $user->getUserComment();
         $infoArray['status'] = $user->getStatus();
 


### PR DESCRIPTION
```
The desired behavior is that the "related groups" on the detail page of a room user is removed if the groups are turned off in the room settings. 
If groups are turned on or "hidden" in the room settings the related groups should be displayed on the detail page of a room user.
```