### PR TITLE
Commit code 4655 - Users under "linked entries" are listed twice

### DIFF
--- a/src/Controller/LinkController.php
+++ b/src/Controller/LinkController.php
@@ -265,7 +265,6 @@ class LinkController extends AbstractController
             if ($tempLabel->getLabelType() == 'group') {
                 $group = $groupService->getGroup($tempLabel->getItemID());
                 $membersList = $group->getMemberItemList();
-                $linkedItems = $membersList->to_array();
             }
         }
         $ids = $item->getAllLinkeditemIDArray();
@@ -337,7 +336,6 @@ class LinkController extends AbstractController
             if ($tempLabel->getLabelType() == 'group') {
                 $group = $groupService->getGroup($tempLabel->getItemID());
                 $membersList = $group->getMemberItemList();
-                $linkedItems = $membersList->to_array();
             }
         }
         $ids = $item->getAllLinkedItemIDArray();


### PR DESCRIPTION
```
The error that the users of a group are listed twice under linked entries in a group appeared again just like in [#4508](https://projects.effective-webwork.de/work_packages/4508). 

The users should only be listed once.
```