### PR TITLE
Commit code 4489 - Restricting in the monthly calendar view

### DIFF
--- a/src/Controller/DateController.php
+++ b/src/Controller/DateController.php
@@ -2066,15 +2066,10 @@ class DateController extends BaseController
             'hide-past-dates' => $hidePastDates,
         ];
 
-        $listAction = $this->generateUrl('app_date_list', [
-            'roomId' => $room->getItemID()
-        ]);
-        $calendarAction = $this->generateUrl('app_date_calendar', [
-            'roomId' => $room->getItemID()
-        ]);
-
         return $this->createForm(DateFilterType::class, $defaultFilterValues, [
-            'action' => $viewAsCalendar ? $calendarAction: $listAction,
+            'action' => $this->generateUrl($viewAsCalendar ? 'app_date_calendar' : 'app_date_list', [
+                'roomId' => $room->getItemID(),
+            ]),
             'hasHashtags' => $room->withBuzzwords(),
             'hasCategories' => $room->withTags(),
         ]);

--- a/src/Controller/DateController.php
+++ b/src/Controller/DateController.php
@@ -312,7 +312,7 @@ class DateController extends BaseController
         int $roomId
     ) {
         $roomItem = $this->getRoom($roomId);
-        $filterForm = $this->createFilterForm($roomItem, false);
+        $filterForm = $this->createFilterForm($roomItem, false, true);
 
         // apply filter
         $filterForm->handleRequest($request);
@@ -2054,9 +2054,11 @@ class DateController extends BaseController
     /**
      * @param cs_room_item $room
      * @param bool $hidePastDates Default state for hide past dates filter
+     * @param bool $viewAsCalendar Wheter the form's action should point to the calendar view (true),
+     * or else to list view(false): defaults to else
      * @return FormInterface
      */
-    private function createFilterForm($room, $hidePastDates = true)
+    private function createFilterForm($room, $hidePastDates = true, $viewAsCalendar = false)
     {
         // setup filter form default values
         $defaultFilterValues = [
@@ -2064,10 +2066,15 @@ class DateController extends BaseController
             'hide-past-dates' => $hidePastDates,
         ];
 
+        $listAction = $this->generateUrl('app_date_list', [
+            'roomId' => $room->getItemID()
+        ]);
+        $calendarAction = $this->generateUrl('app_date_calendar', [
+            'roomId' => $room->getItemID()
+        ]);
+
         return $this->createForm(DateFilterType::class, $defaultFilterValues, [
-            'action' => $this->generateUrl('app_date_list', [
-                'roomId' => $room->getItemID(),
-            ]),
+            'action' => $viewAsCalendar ? $calendarAction: $listAction,
             'hasHashtags' => $room->withBuzzwords(),
             'hasCategories' => $room->withTags(),
         ]);


### PR DESCRIPTION
```
If you are in the section "dates" in the monthly calendar and want to restrict e. g. for tags or calendars the results will be shown as a list. 
It should be possibly to restrict the calendar in the monthly calendar view. So that you can choose for example a calendar, tags, etc. in the restrict list and the result / the restrictions are shown in the monthly calendar view.

That means that the view should stay the same if you restrict the date entries. 
If the view was a list view the results should be shown in a list. 
If the view was a monthly calendar view the results should be shown in a monthly calendar view.
```