### PR TITLE
Commit code 4633 - Always create a group workspace when creating a group

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -17,6 +17,7 @@ use App\Services\LegacyEnvironment;
 use App\Utils\DiscService;
 use App\Utils\RoomService;
 use App\Utils\UserService;
+use App\Utils\GroupService;
 use cs_user_item;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -34,6 +35,21 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class ProfileController extends AbstractController
 {
+
+    /**
+     * @var GroupService
+     */
+    private GroupService $groupService;
+
+    /**
+     * @required
+     * @param GroupService $groupService
+     */
+    public function setGroupService(GroupService $groupService): void
+    {
+        $this->groupService = $groupService;
+    }
+
     /**
      * @Route("/room/{roomId}/user/{itemId}/general")
      * @Template
@@ -462,6 +478,20 @@ class ProfileController extends AbstractController
                 $membershipManager->leaveWorkspace($roomItem, $account);
 
                 return $this->redirect($portalUrl);
+            }
+            if($request->query->has('groupId')){
+                $groupId = $request->query->get('groupId');
+                $roomEndId = $request->query->get('roomEndId');
+                $group = $this->groupService->getGroup($groupId);
+                $membershipManager->leaveGroup($group, $account);
+                $membershipManager->leaveWorkspace($roomItem, $account);
+                $group = $this->groupService->getGroup($groupId);
+                $roomItem->delete();
+                $group->delete();
+                return $this->redirectToRoute('app_group_list', [
+                    'roomId' => $roomEndId
+                ]);
+
             }
         }
 

--- a/src/Facade/MembershipManager.php
+++ b/src/Facade/MembershipManager.php
@@ -75,4 +75,18 @@ class MembershipManager
         $event = new UserLeftRoomEvent($userInWorkspace, $room);
         $this->eventDispatcher->dispatch($event);
     }
+    /**
+     * Return Boolean if the last moderator
+     * @param cs_room_item $room
+     * @param Account $account
+     * @return bool
+     */
+    public function isLastModerator(cs_room_item $room, $currentUser): bool
+    {
+        $usersInWorkspace = $this->userService->getUserModeratorsInContext($room->getItemID());
+        if ($usersInWorkspace && ($usersInWorkspace->getCount() <= 1) && ($currentUser->getStatus() === '3' )) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/Form/DataTransformer/GroupTransformer.php
+++ b/src/Form/DataTransformer/GroupTransformer.php
@@ -20,7 +20,7 @@ class GroupTransformer extends AbstractTransformer
         if ($groupItem) {
             $groupData['title'] = html_entity_decode($groupItem->getTitle());
             $groupData['description'] = $groupItem->getDescription();
-            $groupData['activate'] = $groupItem->isGroupRoomActivated();
+            $groupData['activate'] = true;
             
             if ($groupItem->isNotActivated()) {
                 $groupData['hidden'] = true;

--- a/src/Form/Type/GroupType.php
+++ b/src/Form/Type/GroupType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class GroupType extends AbstractType
 {
@@ -31,6 +32,14 @@ class GroupType extends AbstractType
                 ),
                 'translation_domain' => 'material',
             ))
+            ->add('master_template', ChoiceType::class, [
+                'choices' => $options['templates'],
+                'placeholder' => 'Choose a template',
+                'required' => false,
+                'mapped' => false,
+                'label' => 'Template',
+                'translation_domain' => 'group',
+            ])
             ->add('hidden', CheckboxType::class, array(
                 'label' => 'hidden',
                 'required' => false,
@@ -89,7 +98,7 @@ class GroupType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setRequired(['placeholderText', 'hashtagMappingOptions', 'categoryMappingOptions', 'room']);
+        $resolver->setRequired(['placeholderText', 'hashtagMappingOptions', 'categoryMappingOptions', 'room', 'templates']);
 
         $resolver->setDefaults(['translation_domain' => 'form']);
 

--- a/src/Utils/UserService.php
+++ b/src/Utils/UserService.php
@@ -875,4 +875,19 @@ class UserService
             }
         }
     }
+    /**
+     * @param Account $account
+     * @param int $contextId
+     * @return cs_user_item|null
+     */
+    public function getUserModeratorsInContext(int $contextId): ?\cs_list
+    {
+        $this->userManager->resetLimits();
+        $this->userManager->setContextLimit($contextId);
+        $this->userManager->setStatusLimit(3);
+        $this->userManager->select();
+
+        $userList = $this->userManager->get();
+        return $userList;
+    }
 }

--- a/templates/group/detail_print.html.twig
+++ b/templates/group/detail_print.html.twig
@@ -75,7 +75,7 @@
                                 {% else %}
                                     <span class="uk-text-bold">{{'no grouproom'|trans({},'group') }}</span><br/>
                                     <p>
-                                    {{'no grouproom description text'|trans({},'group') }}    
+                                    {{'no grouproom description text'|trans({},'group') }}
                                     </p>
                                 {% endif %}
                                 </div>

--- a/templates/group/edit.html.twig
+++ b/templates/group/edit.html.twig
@@ -10,6 +10,15 @@
                     {{ form_widget(form.title) }}
             </div>
         </div>
+        <div class="uk-margin-small-left uk-flex">
+            <div class="uk-form-label">
+                {{ form_label(form.master_template) }}
+            </div>
+            <div  class="uk-margin-small-top" >
+                {{ form_widget(form.master_template) }}
+            </div>
+
+        </div>
 
             {% if group.creator.itemId == currentUser.itemId or currentUser.isModerator %}
             <div class="uk-margin-small-left uk-flex">

--- a/templates/group/editgrouproom.html.twig
+++ b/templates/group/editgrouproom.html.twig
@@ -1,44 +1,12 @@
 {% form_theme form 'form/uikit_stacked_layout_date.html.twig' %}
 {% import 'date/macros.html.twig' as macrosDate %}
 
-<div class="uk-margin-left uk-margin-right uk-margin-bottom uk-position-relative">
-    <a name="description"></a>
-    <div class="uk-grid uk-margin-small-bottom">
-        <div class="uk-width-9-10">
-            <h4 class="cs-detail-section-header">
-                <span class="cs-detail-section-header-background">{{ 'edit grouproom'|trans({},'group')}}
-                 </span>
-            </h4>
-        </div>
-    </div>
-<div>
-
 <div class="uk-margin-left uk-margin-bottom uk-position-relative uk-padding-remove cs-description-inline">
     {% include 'utils/save_spinner.html.twig' %}
     <div class="uk-form-horizontal">
         {{ form_start(form) }}
         {{ form_errors(form) }}
-        <div class="uk-flex">
-            <div class="uk-grid">
-                <div class="uk-width-2-10">
-                    {{ form_label(form.activate) }}
-                </div>
-                <div class="uk-width-8-10">
-                    {{ form_widget(form.activate) }}
-                </div>
-            </div>
-        </div>
-        <div class="uk-flex">
-            <div class="uk-grid">
-                <div class="uk-width-1-10">
-                    {{ form_label(form.master_template) }}
-                </div>
-                <div class="uk-width-9-10">
-                    {{ form_widget(form.master_template) }}
-                </div>
-            </div>
-        </div>
-        <div class="uk-flex uk-margin-small-top">
+          <div class="uk-flex uk-margin-small-top">
             <div class="uk-margin-small-left">
                 {{ form_row(form.save) }}
             </div>

--- a/templates/group/macros.html.twig
+++ b/templates/group/macros.html.twig
@@ -436,26 +436,20 @@
                                                     <span class="uk-icon-large uk-icon-button uk-icon-remove" data-uk-tooltip title="{{'no access'|trans({}, 'room') }}"> </span>
                                                 {% endif %}
                                             </div>
-                                        {% else %}
-                                            <span class="uk-icon-large uk-icon-button uk-icon-remove" data-uk-tooltip title="{{'no grouproom'|trans({},'group') }}"> </span>
+
                                         {% endif %}
                                     </div>
                                     <div class="uk-width-2-5 uk-text-left uk-margin-right">
                                         {% if item.isGroupRoomActivated and item.groupRoomItem %}
                                             <span class="uk-text-bold">{{item.groupRoomItem.title|decodeHtmlEntity}}</span><br/>
                                             <p>
-                                            {{'grouproom description text'|trans({},'group') }}    
+                                            {{'grouproom description text'|trans({},'group') }}
                                             </p>
                                             <p>
                                             {{'grouproom access'|trans({},'group') }}
                                             </p>
                                             <p>
                                             {{ macros.contextLink(roomId, item.getGroupRoomItem, roomMemberStatus, (isRoot or userIsGroupMember)) }}
-                                            </p>
-                                        {% else %}
-                                            <span class="uk-text-bold">{{'no grouproom'|trans({},'group') }}</span><br/>
-                                            <p>
-                                            {{'no grouproom description text'|trans({},'group') }}    
                                             </p>
                                         {% endif %}
                                     </div>


### PR DESCRIPTION
When creating a new group, there is a group workspace section in the form consisting of a checkbox asking if a group workspace should be created and a select box for selecting a template for the room creation.

The checkbox must be removed and the checked behaviour (creating a grouproom) should become the new default.

Also, the template selection must be moved to the top form section. Technically this means moving the "master_template" field from GrouproomType to GroupType and removing GrouproomType. The field should be added directly below the title field.