### PR TITLE
Commit code 4628 - On user detail page "related groups" are shown when groups are off in the room

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -676,6 +676,7 @@ class UserController extends BaseController
             'pathTopicItem' => $pathTopicItem,
             'isSelf' => $isSelf,
             'moderatorListLength' => $moderatorListLength,
+            'showRelatedGroups' => $infoArray['showRelatedGroups']
         );
     }
 
@@ -789,11 +790,12 @@ class UserController extends BaseController
                 $lastItemId = $users[sizeof($users) - 1]->getItemId();
             }
         }
-
+        $showRelatedGroups = false;
         $groups = [];
         $context_item = $this->legacyEnvironment->getCurrentContextItem();
         $conf = $context_item->getHomeConf();
         if(strpos($conf, "group_show") == true) {
+            $showRelatedGroups = true;
             $groups = $this->userService->getUser($itemId)->getGroupList()->to_array();
         }
 
@@ -819,6 +821,7 @@ class UserController extends BaseController
         $infoArray['linkedGroups'] = $groups;
         $infoArray['comment'] = $user->getUserComment();
         $infoArray['status'] = $user->getStatus();
+        $infoArray['showRelatedGroups'] = $showRelatedGroups;
 
         return $infoArray;
     }

--- a/templates/user/detail.html.twig
+++ b/templates/user/detail.html.twig
@@ -233,16 +233,18 @@
                     <div id="links{{ user.itemId }}">
                         <hr class="uk-width-9-10"/>
                         <article class="uk-article uk-margin-left uk-margin-right">
+                            {% if showRelatedGroups %}
                             <a name="linked-groups"></a>
                             {# title row #}
                             <div class="uk-grid uk-margin-small-bottom">
                                 <div class="uk-width-9-10">
                                     <h4 class="cs-detail-section-header">
                                         {{'linked groups'|trans({}) }}
-                                       ({{linkedGroups|length}})
+                                        ({{linkedGroups|length}})
                                     </h4>
                                 </div>
-                            </div>
+                                </div>
+                             {% endif %}
                             <div class="uk-width-9-10 uk-margin-remove uk-padding-remove">
                                 <div class="uk-grid">
                                    {% for group in linkedGroups %}


### PR DESCRIPTION
The desired behavior is that the "related groups" on the detail page of a room user is removed if the groups are turned off in the room settings. 
If groups are turned on or "hidden" in the room settings the related groups should be displayed on the detail page of a room user.