### PR TITLE
Teamq/4638 -  Restriction list should be expanded

### DIFF
--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -1575,8 +1575,8 @@ class GroupController extends BaseController
             'action' => $this->generateUrl('app_group_list', [
                 'roomId' => $room->getItemID(),
             ]),
-            'hasHashtags' => false,
-            'hasCategories' => false,
+            'hasHashtags' => true,
+            'hasCategories' => true,
         ]);
     }
 

--- a/src/Filter/RubricFilterType.php
+++ b/src/Filter/RubricFilterType.php
@@ -38,7 +38,9 @@ class RubricFilterType extends AbstractType
                 $roomId = $attributes->getInt('roomId');
 
                 $filterableRubrics = $this->roomService->getFilterableRubrics($roomId);
-
+                if ($attributes->has('_route') && $attributes->get('_route') == 'app_group_list') {
+                    $filterableRubrics = array_diff($filterableRubrics, ["group"]);
+                }
                 // group
                 if (in_array('group', $filterableRubrics)) {
                     $builder

--- a/src/Utils/GroupService.php
+++ b/src/Utils/GroupService.php
@@ -93,6 +93,41 @@ class GroupService
                 $this->groupManager->setInactiveEntriesLimit(\cs_manager::SHOW_ENTRIES_ACTIVATED_DEACTIVATED);
             }
         }
+        // rubrics
+        if ($formData['rubrics']) {
+            // group
+            if (isset($formData['rubrics']['group'])) {
+                $relatedLabel = $formData['rubrics']['group'];
+                $this->groupManager->setGroupLimit($relatedLabel->getItemId());
+            }
+
+            // topic
+            if (isset($formData['rubrics']['topic'])) {
+                $relatedLabel = $formData['rubrics']['topic'];
+                $this->groupManager->setTopicLimit($relatedLabel->getItemId());
+            }
+        }
+
+        // hashtag
+        if (isset($formData['hashtag'])) {
+            if (isset($formData['hashtag']['hashtag'])) {
+                $hashtag = $formData['hashtag']['hashtag'];
+                $itemId = $hashtag->getItemId();
+                $this->groupManager->setBuzzwordLimit($itemId);
+            }
+        }
+
+        // category
+        if (isset($formData['category'])) {
+            if (isset($formData['category']['category'])) {
+                $categories = $formData['category']['category'];
+
+                if (!empty($categories)) {
+                    $this->groupManager->setTagArrayLimit($categories);
+                }
+            }
+        }
+
     }
     
     public function getNewGroup()


### PR DESCRIPTION
The restriction list in the rubric groups should be expanded.

The following restrictions should be added: 

Hide groups without membership (just like in the "All rooms" list)
Topics
Categories (if they are enabled in the room settings)
Tags  (if they are enabled in the room settings)