### PR TITLE
Commit code 4627 - resolve comments

### DIFF
--- a/src/Facade/MembershipManager.php
+++ b/src/Facade/MembershipManager.php
@@ -83,8 +83,18 @@ class MembershipManager
      */
     public function isLastModerator(cs_room_item $room, $currentUser): bool
     {
+        $isSameUser = false;
         $usersInWorkspace = $this->userService->getUserModeratorsInContext($room->getItemID());
-        if ($usersInWorkspace && ($usersInWorkspace->getCount() <= 1) && ($currentUser->getStatus() === '3' )) {
+        if (!empty($usersInWorkspace)) {
+            $obj = $usersInWorkspace->getFirst();
+            while ($obj) {
+                if ($obj->getUserID() === $currentUser->getUserID()){
+                    $isSameUser = true;
+                }
+                $obj = $usersInWorkspace->getNext();
+            }
+        }
+        if ($usersInWorkspace && ($usersInWorkspace->getCount() <= 1) && ($currentUser->getStatus() === '3' ) && $isSameUser) {
             return true;
         }
         return false;

--- a/src/Utils/UserService.php
+++ b/src/Utils/UserService.php
@@ -882,6 +882,7 @@ class UserService
      */
     public function getUserModeratorsInContext(int $contextId): ?\cs_list
     {
+        $this->userManager->reset();
         $this->userManager->resetLimits();
         $this->userManager->setContextLimit($contextId);
         $this->userManager->setStatusLimit(3);


### PR DESCRIPTION
```
Something went wrong there. Now if you click on leave if you are the moderator the group with the group workspace gets deleted. 
In the screen recording (you can find in the files) I show at first how it should be and after that how it is right now.

And if you are a normal user you can just leave without getting redirected to the "Cancel membership" page. Shown in the other screen recording. But it should be like I described in the comment above you should always be redirected to the cancel membership page
```