### PR TITLE
Commit code 4611 - resolve comments

### DIFF
--- a/templates/item/macros.html.twig
+++ b/templates/item/macros.html.twig
@@ -145,7 +145,10 @@
     <div class="uk-grid">
         {% if withCategories %}
             <div class="uk-width-1-3">
-                <strong>{{ 'categories'|trans({}, "room") }}:</strong> <br/>
+                {% if (item.tagsArray|length) > 0 %}
+                    <strong>{{ 'categories'|trans({}, "room") }}:</strong> <br/>
+                {% endif %}
+
                 {% set count = 1 %}
                 {% if (item.tagsArray|length) < 4 %}
                     {% if (item.tagsArray|length) == 0 %}


### PR DESCRIPTION
`In all rubrics the heading "Categories:" is still shown when there are no categories assigned to the entry. This should be removed as well. `