### PR TITLE
2516 omit modifier info for external calendar entries

### DIFF
--- a/templates/date/feed.html.twig
+++ b/templates/date/feed.html.twig
@@ -25,8 +25,8 @@
                             {{ macros.userIcon(date.modificatorItem) }}
                         {% endif %}
                     {% else %}
-                        <div class="uk-thumbnail uk-border-circle cs-comment-thumbnail" style="height:42px; width:42px;" data-uk-tooltip title="{{ date.calendar.title }}">
-                            <div class="uk-container-center uk-margin-small-top" style="width:24px; height:24px;">
+                        <div class="uk-vertical-align uk-text-center uk-thumbnail uk-border-circle cs-comment-thumbnail" style="height:42px; width:42px;" data-uk-tooltip title="{{ date.calendar.title }}">
+                            <div class="uk-container-center uk-vertical-align-middle" style="width:24px; height:24px;">
                                 <i class="uk-icon-medium uk-icon-calendar" style="color:{{ date.calendar.color }}; width:24px; height:24px;"></i>
                             </div>
                         </div>

--- a/templates/date/macros.html.twig
+++ b/templates/date/macros.html.twig
@@ -38,10 +38,18 @@
                                     <div class="uk-width-1-1">
                                         <div class="uk-flex">
                                             <div class="uk-margin-right">
-                                                {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
-                                                    {{ macros.userIconLink(item.modificatorItem) }}
+                                                {% if not item.isExternal %}
+                                                    {% if not item.modificatorItem.isDeleted and item.modificatorItem.isUser %}
+                                                        {{ macros.userIconLink(item.modificatorItem) }}
+                                                    {% else %}
+                                                        {{ macros.userIcon(item.modificatorItem) }}
+                                                    {% endif %}
                                                 {% else %}
-                                                    {{ macros.userIcon(item.modificatorItem) }}
+                                                    <div class="uk-vertical-align uk-text-center uk-thumbnail uk-border-circle cs-comment-thumbnail" style="height:42px; width:42px;" data-uk-tooltip title="{{ item.calendar.title }}">
+                                                        <div class="uk-container-center uk-vertical-align-middle" style="width:24px; height:24px;">
+                                                            <i class="uk-icon-medium uk-icon-calendar" style="color:{{ item.calendar.color }}; width:24px; height:24px;"></i>
+                                                        </div>
+                                                    </div>
                                                 {% endif %}
                                             </div>
                                             <div class="uk-margin-right">
@@ -50,7 +58,9 @@
                                                 {% else %}
                                                     {{ 'last changed'|trans({})|capitalize }}: {{ item.creationDate|craue_date }} {{ item.creationDate|craue_time }}<br/>
                                                 {% endif %}
-                                                {{ 'changed by'|trans({})|capitalize }}: {{ macros.userFullname(item.modificatorItem) }}
+                                                {% if not item.isExternal %}
+                                                    {{ 'changed by'|trans({})|capitalize }}: {{ macros.userFullname(item.modificatorItem) }}
+                                                {% endif %}
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Date detail views now:
- hide the modifier information
- display a colored calendar icon instead of the modifier's icon

Bonus fixes:
- in date list view, the calendar icons of external calendar entries now get centered correctly