### PR TITLE
Feature/4781 v10013

### DIFF
--- a/legacy/classes/cs_translator.php
+++ b/legacy/classes/cs_translator.php
@@ -765,18 +765,29 @@ class cs_translator {
       return $retour;
    }
 
-   /** setContext
-    * this methode set the context (community or project)
+   /**
+    * Returns the context (community, project or grouproom).
     *
     * @param string context
     */
-   function setContext ($value) {
+   public function getContext(): string
+   {
+       return $this->_context;
+   }
+
+   /**
+    * Sets the context (community, project or grouproom).
+    *
+    * @param string context
+    */
+   public function setContext($value): void
+   {
       $this->_context = (string)$value;
    }
 
    function _inCommunityRoom () {
       $retour = false;
-      if ( isset($this->_context) and $this->_context == 'community' ) {
+      if (isset($this->_context) and $this->_context == CS_COMMUNITY_TYPE) {
          $retour = true;
       }
       return $retour;
@@ -784,7 +795,7 @@ class cs_translator {
 
    function _inProjectRoom () {
       $retour = false;
-      if ( isset($this->_context) and $this->_context == 'project' ) {
+      if (isset($this->_context) and $this->_context == CS_PROJECT_TYPE) {
          $retour = true;
       }
       return $retour;
@@ -792,7 +803,7 @@ class cs_translator {
 
    function _inGroupRoom () {
       $retour = false;
-      if ( isset($this->_context) and $this->_context == CS_GROUPROOM_TYPE ) {
+      if (isset($this->_context) and $this->_context == CS_GROUPROOM_TYPE) {
          $retour = true;
       }
       return $retour;
@@ -800,11 +811,11 @@ class cs_translator {
 
    function initFromContext ( $context_item ) {
       if ($context_item->isCommunityRoom()) {
-         $this->setContext('community');
+         $this->setContext(CS_COMMUNITY_TYPE);
          $portal_item = $context_item->getContextItem();
          $this->setTimeMessageArray($portal_item->getTimeTextArray());
       } elseif ($context_item->isProjectRoom()) {
-         $this->setContext('project');
+         $this->setContext(CS_PROJECT_TYPE);
          $portal_item = $context_item->getContextItem();
          $this->setTimeMessageArray($portal_item->getTimeTextArray());
       } elseif ($context_item->isGroupRoom()) {
@@ -816,10 +827,10 @@ class cs_translator {
          $portal_item = $context_item->getContextItem();
          $this->setTimeMessageArray($portal_item->getTimeTextArray());
       } elseif ($context_item->isPortal()) {
-         $this->setContext('portal');
+         $this->setContext(CS_PORTAL_TYPE);
          $this->setTimeMessageArray($context_item->getTimeTextArray());
       } else {
-         $this->setContext('server');
+         $this->setContext(CS_SERVER_TYPE);
       }
       $this->setRubricTranslationArray($context_item->getRubricTranslationArray());
       $this->setEmailTextArray($context_item->getEmailTextArray());

--- a/src/EventSubscriber/AutoRoomMembershipSubscriber.php
+++ b/src/EventSubscriber/AutoRoomMembershipSubscriber.php
@@ -12,6 +12,9 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class AutoRoomMembershipSubscriber implements EventSubscriberInterface
 {
+    // separator which separates multiple room identifiers
+    private const SEPARATOR = ';';
+
     /**
      * @var UserCreatorFacade
      */
@@ -62,7 +65,7 @@ class AutoRoomMembershipSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $membershipIdentifiers = explode(',', trim($membershipIdentifierString));
+        $membershipIdentifiers = explode(self::SEPARATOR, trim($membershipIdentifierString));
         if (empty($membershipIdentifiers)) {
             return;
         }

--- a/src/EventSubscriber/AutoRoomMembershipSubscriber.php
+++ b/src/EventSubscriber/AutoRoomMembershipSubscriber.php
@@ -59,7 +59,7 @@ class AutoRoomMembershipSubscriber implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
-        $paramBag = $request->request;
+        $paramBag = $request->server;
         $membershipIdentifierString = $paramBag->get($membershipIdentifiersKey);
         if (empty($membershipIdentifierString)) {
             return;

--- a/src/Utils/AccountMail.php
+++ b/src/Utils/AccountMail.php
@@ -110,6 +110,9 @@ class AccountMail
         $legacyTranslator = $this->legacyEnvironment->getTranslationObject();
         $room = $this->legacyEnvironment->getCurrentContextItem();
 
+        $oldContextType = $legacyTranslator->getContext();
+        $legacyTranslator->setContext($room->getType());
+
         $body = $legacyTranslator->getEmailMessage('MAIL_BODY_HELLO', $multipleRecipients ? ' ' : $user->getFullname());
         $body .= "<br/><br/>";
 
@@ -196,6 +199,8 @@ class AccountMail
             $room->getTitle());
         $message = str_replace("\n","<br/>", $message);
         $body .= $message;
+
+        $legacyTranslator->setContext($oldContextType);
 
         return $body;
     }

--- a/src/Utils/UserroomService.php
+++ b/src/Utils/UserroomService.php
@@ -50,10 +50,13 @@ class UserroomService
 
         $userroomTemplate = $room->getUserRoomTemplateItem();
 
+        $roomModerators = $this->userService->getModeratorsForContext($roomContext);
+        $firstRoomModerator = !empty($roomModerators) ? $roomModerators[0] : null;
+
         /**
          * @var $newRoom \cs_userroom_item
          */
-        $newRoom = $this->roomService->createRoom($roomManager, $roomContext, $roomTitle, "", $userroomTemplate);
+        $newRoom = $this->roomService->createRoom($roomManager, $roomContext, $roomTitle, "", $userroomTemplate, $firstRoomModerator, $firstRoomModerator);
         if (!$newRoom) {
             return null;
         }
@@ -73,7 +76,6 @@ class UserroomService
         // add room moderators
         $userContext = $newRoom->getItemID();
         $moderatorIsRoomOwner = false;
-        $roomModerators = $this->userService->getModeratorsForContext($roomContext);
         foreach ($roomModerators as $moderator) {
             $userroomModerator = $this->userService->cloneUser($moderator, $userContext, 3);
             $userroomModerator->setLinkedProjectUserItemID($moderator->getItemID());

--- a/tests/Unit/AutoRoomMembershipSubscriberTest.php
+++ b/tests/Unit/AutoRoomMembershipSubscriberTest.php
@@ -58,7 +58,7 @@ class AutoRoomMembershipSubscriberTest extends Unit
         $request = $this->makeEmpty(Request::class, [
             'request' => $this->make(ParameterBag::class, [
                 'parameters' => [
-                    'roomslugs' => join(',', $roomslugs)
+                    'roomslugs' => join(';', $roomslugs)
                 ]
             ])
         ]);

--- a/translations/portal.de.xlf
+++ b/translations/portal.de.xlf
@@ -1486,7 +1486,7 @@
             </trans-unit>
             <trans-unit id="portal_auth_membership_identifier_help">
                 <source>portal.auth.membership_identifier_help</source>
-                <target>Bezeichner für Komma-separierte Server-Umgebungsinformationen zur automatischen Raumteilnahme</target>
+                <target>Bezeichner für Semikolon-separierte Server-Umgebungsinformationen zur automatischen Raumteilnahme</target>
             </trans-unit>
         </body>
     </file>

--- a/translations/portal.en.xlf
+++ b/translations/portal.en.xlf
@@ -1486,7 +1486,7 @@
             </trans-unit>
             <trans-unit id="portal_auth_membership_identifier_help">
                 <source>portal.auth.membership_identifier_help</source>
-                <target>Identifier for comma-separated server environment information used when automatically creating workspace members</target>
+                <target>Identifier for semicolon-separated server environment information used when automatically creating workspace members</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
PR für [#4781](https://projects.effective-webwork.de/projects/commsy/work_packages/4781) mit 10.0 als Base Branch.

Dieser PR enthält Verbesserungen & Änderungen für die automatische Raumteilnahme:

1. das Trennzeichen bei mehreren Raum-Bezeichnern ist jetzt ein Semikolon
2. es wird `$request->server` und nicht `$request->request` verwendet
3. automatisch erstellte Raum-Nutzer:Innen werden jetzt stets direkt freigeschaltet
4. der/die Nutzer:In wird via Email über die Raum-Freischaltung informiert
5. falls nötig werden auch entsprechende Benutzerräume automatisch mit erstellt
