### PR TITLE
4918 Activating reader view shouldn't display the status view + more fixes for 10.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ COPY docker/php/php-fpm.d/zz-docker.conf /usr/local/etc/php-fpm.d/zz-docker.conf
 RUN mkdir -p /var/run/php
 
 # wkhtmltopdf
-COPY --from=surnet/alpine-wkhtmltopdf:3.16.2-0.12.6-small /bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
+COPY --from=surnet/alpine-wkhtmltopdf:3.17.0-0.12.6-full /bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1

--- a/src/Controller/AnnouncementController.php
+++ b/src/Controller/AnnouncementController.php
@@ -104,7 +104,7 @@ class AnnouncementController extends BaseController
         // or from query paramters (AJAX)
         $announcementFilter = $request->get('announcementFilter');
         if (!$announcementFilter) {
-            $announcementFilter = $request->query->get('announcement_filter');
+            $announcementFilter = $request->query->all('announcement_filter');
         }
 
         /** @var cs_room_item $roomItem */
@@ -728,7 +728,7 @@ class AnnouncementController extends BaseController
     ) {
         if ($selectAll) {
             if ($request->query->has('announcement_filter')) {
-                $currentFilter = $request->query->get('announcement_filter');
+                $currentFilter = $request->query->all('announcement_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -224,10 +224,10 @@ abstract class BaseController extends AbstractController
                 throw new Exception('select all is not set, but no "positiveItemIds" were provided');
             }
 
-            $positiveItemIds = $request->request->get('positiveItemIds');
+            $positiveItemIds = $request->request->all('positiveItemIds');
         } else {
             if ($request->request->has('negativeItemIds')) {
-                $negativeItemIds = $request->request->get('negativeItemIds');
+                $negativeItemIds = $request->request->all('negativeItemIds');
             }
         }
 

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -126,7 +126,7 @@ abstract class BaseController extends AbstractController
         $categories = $this->labelService->getCategories($roomId, true);
 
         // NOTE: CategorizeAction.ts extracts the chosen choices and XHRAction->execute() stores them as request 'payload'
-        $payload = $request->request->get('payload', []);
+        $payload = $request->request->all('payload', []);
         $choices = $payload['choices'] ?? [];
 
         // provide a form with custom form options that are required for this action
@@ -169,7 +169,7 @@ abstract class BaseController extends AbstractController
         $hashtags = $this->labelService->getHashtags($roomId);
 
         // NOTE: HashtagAction.ts extracts the chosen choices and XHRAction->execute() stores them as request 'payload'
-        $payload = $request->request->get('payload', []);
+        $payload = $request->request->all('payload', []);
         $choices = $payload['choices'] ?? [];
 
         // provide a form with custom form options that are required for this action

--- a/src/Controller/DateController.php
+++ b/src/Controller/DateController.php
@@ -1835,7 +1835,7 @@ class DateController extends BaseController
 
         $recurring = false;
         if ($request->request->has('payload')) {
-            $payload = $request->request->get('payload');
+            $payload = $request->request->all('payload');
 
             $recurring = isset($payload['recurring']) ?? false;
         }

--- a/src/Controller/DateController.php
+++ b/src/Controller/DateController.php
@@ -89,7 +89,7 @@ class DateController extends BaseController
         // or from query paramters (AJAX)
         $dateFilter = $request->get('dateFilter');
         if (!$dateFilter) {
-            $dateFilter = $request->query->get('date_filter');
+            $dateFilter = $request->query->all('date_filter');
         }
 
         if ($dateFilter) {
@@ -511,7 +511,7 @@ class DateController extends BaseController
         // or from query paramters (AJAX)
         $dateFilter = $request->get('dateFilter');
         if (!$dateFilter) {
-            $dateFilter = $request->query->get('date_filter');
+            $dateFilter = $request->query->all('date_filter');
         }
 
         $startDate = $request->get('start');
@@ -1888,7 +1888,7 @@ class DateController extends BaseController
     ) {
         if ($selectAll) {
             if ($request->query->has('date_filter')) {
-                $currentFilter = $request->query->get('date_filter');
+                $currentFilter = $request->query->all('date_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/DiscussionController.php
+++ b/src/Controller/DiscussionController.php
@@ -71,7 +71,7 @@ class DiscussionController extends BaseController
         // or from query paramters (AJAX)
         $discussionFilter = $request->get('discussionFilter');
         if (!$discussionFilter) {
-            $discussionFilter = $request->query->get('discussion_filter');
+            $discussionFilter = $request->query->all('discussion_filter');
         }
 
         $roomItem = $this->getRoom($roomId);
@@ -1113,7 +1113,7 @@ class DiscussionController extends BaseController
         // get the discussion manager service
         if ($selectAll) {
             if ($request->query->has('discussion_filter')) {
-                $currentFilter = $request->query->get('discussion_filter');
+                $currentFilter = $request->query->all('discussion_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -188,7 +188,7 @@ class GroupController extends BaseController
         // or from query paramters (AJAX)
         $groupFilter = $request->get('groupFilter');
         if (!$groupFilter) {
-            $groupFilter = $request->query->get('group_filter');
+            $groupFilter = $request->query->all('group_filter');
         }
 
         $roomManager = $this->legacyEnvironment->getRoomManager();
@@ -1405,7 +1405,7 @@ class GroupController extends BaseController
         // get the user service
         if ($selectAll) {
             if ($request->query->has('group_filter')) {
-                $currentFilter = $request->query->get('group_filter');
+                $currentFilter = $request->query->all('group_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/MarkedController.php
+++ b/src/Controller/MarkedController.php
@@ -55,7 +55,7 @@ class MarkedController extends BaseController
         // or from query parameters (AJAX)
         $markedFilter = $request->get('markFilter');
         if (!$markedFilter) {
-            $markedFilter = $request->query->get('marked_filter');
+            $markedFilter = $request->query->all('marked_filter');
         }
 
         $roomItem = $this->loadRoom($roomId);
@@ -221,7 +221,7 @@ class MarkedController extends BaseController
     ) {
         if ($selectAll) {
             if ($request->query->has('marked_filter')) {
-                $currentFilter = $request->query->get('marked_filter');
+                $currentFilter = $request->query->all('marked_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -387,7 +387,7 @@ class MaterialController extends BaseController
         int $itemId
     ): Response {
         if ($request->request->has('payload')) {
-            $payload = $request->request->get('payload');
+            $payload = $request->request->all('payload');
 
             if (isset($payload['read']) && $payload['read']) {
                 $read = $payload['read'];

--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -118,7 +118,7 @@ class MaterialController extends BaseController
         // or from query paramters (AJAX)
         $materialFilter = $request->get('materialFilter');
         if (!$materialFilter) {
-            $materialFilter = $request->query->get('material_filter');
+            $materialFilter = $request->query->all('material_filter');
         }
 
         $roomItem = $this->getRoom($roomId);
@@ -1480,7 +1480,7 @@ class MaterialController extends BaseController
 
         if ($selectAll) {
             if ($request->query->has('material_filter')) {
-                $currentFilter = $request->query->get('material_filter');
+                $currentFilter = $request->query->all('material_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/MaterialController.php
+++ b/src/Controller/MaterialController.php
@@ -169,12 +169,22 @@ class MaterialController extends BaseController
             $ratingList = $this->assessmentService->getListAverageRatings($itemIds);
         }
 
-        return $this->render('material/feed.html.twig', ['roomId' => $roomId, 'materials' => $materials, 'readerList' => $readerList, 'showRating' => $current_context->isAssessmentActive(), 'showWorkflow' => $current_context->withWorkflow(), 'ratingList' => $ratingList, 'allowedActions' => $allowedActions, 'workflowTitles' => [
-            '0_green' => $roomItem->getWorkflowTrafficLightTextGreen(),
-            '1_yellow' => $roomItem->getWorkflowTrafficLightTextYellow(),
-            '2_red' => $roomItem->getWorkflowTrafficLightTextRed(),
-            '3_none' => '',
-        ]]);
+        return $this->render('material/feed.html.twig', [
+            'roomId' => $roomId,
+            'materials' => $materials,
+            'readerList' => $readerList,
+            'showRating' => $current_context->isAssessmentActive(),
+            'showWorkflow' => $current_context->withWorkflow(),
+            'withTrafficLight' => $roomItem->withWorkflowTrafficLight(),
+            'ratingList' => $ratingList,
+            'allowedActions' => $allowedActions,
+            'workflowTitles' => [
+                '0_green' => $roomItem->getWorkflowTrafficLightTextGreen(),
+                '1_yellow' => $roomItem->getWorkflowTrafficLightTextYellow(),
+                '2_red' => $roomItem->getWorkflowTrafficLightTextRed(),
+                '3_none' => '',
+            ]
+        ]);
     }
 
     #[Route(path: '/room/{roomId}/material')]
@@ -1023,12 +1033,23 @@ class MaterialController extends BaseController
 
         $infoArray = $this->getDetailInfo($roomId, $itemId);
 
-        return $this->render('material/save.html.twig', ['roomId' => $roomId, 'item' => $tempItem, 'modifierList' => $modifierList, 'userCount' => $infoArray['userCount'], 'readCount' => $infoArray['readCount'], 'readSinceModificationCount' => $infoArray['readSinceModificationCount'], 'showRating' => $infoArray['showRating'], 'showWorkflow' => $infoArray['showWorkflow'], 'workflowTitles' => [
-            '0_green' => $roomItem->getWorkflowTrafficLightTextGreen(),
-            '1_yellow' => $roomItem->getWorkflowTrafficLightTextYellow(),
-            '2_red' => $roomItem->getWorkflowTrafficLightTextRed(),
-            '3_none' => '',
-        ]]);
+        return $this->render('material/save.html.twig', [
+            'roomId' => $roomId,
+            'item' => $tempItem,
+            'modifierList' => $modifierList,
+            'userCount' => $infoArray['userCount'],
+            'readCount' => $infoArray['readCount'],
+            'readSinceModificationCount' => $infoArray['readSinceModificationCount'],
+            'showRating' => $infoArray['showRating'],
+            'showWorkflow' => $infoArray['showWorkflow'],
+            'withTrafficLight' => $roomItem->withWorkflowTrafficLight(),
+            'workflowTitles' => [
+                '0_green' => $roomItem->getWorkflowTrafficLightTextGreen(),
+                '1_yellow' => $roomItem->getWorkflowTrafficLightTextYellow(),
+                '2_red' => $roomItem->getWorkflowTrafficLightTextRed(),
+                '3_none' => '',
+            ]
+        ]);
     }
 
     #[Route(path: '/room/{roomId}/material/{itemId}/print')]

--- a/src/Controller/RoomController.php
+++ b/src/Controller/RoomController.php
@@ -403,7 +403,7 @@ class RoomController extends AbstractController
 
         // extract current filter from parameter bag (embedded controller call)
         // or from query paramters (AJAX)
-        $roomFilter = $request->attributes->get('roomFilter') ?: $request->query->get('room_filter');
+        $roomFilter = $request->attributes->get('roomFilter') ?: $request->query->all('room_filter');
 
         // Prepare query builder for active and archived rooms
         $activeRoomQueryBuilder = $roomRepository->getMainRoomQueryBuilder($portal->getId(), $roomTypes, $sort);

--- a/src/Controller/StepController.php
+++ b/src/Controller/StepController.php
@@ -64,7 +64,7 @@ class StepController extends BaseController
     /**
      * @throws Exception
      */
-    #[Route(path: '/room/{roomId}/step/xhr/changesatatus/{itemId}', condition: 'request.isXmlHttpRequest()')]
+    #[Route(path: '/room/{roomId}/step/xhr/changestatus/{itemId}', condition: 'request.isXmlHttpRequest()')]
     public function xhrChangeStatusAction($roomId, $itemId, Request $request, TodoService $todoService): Response
     {
         $items = null;
@@ -72,7 +72,7 @@ class StepController extends BaseController
         $roomToDoItems = $todoService->getTodosById($roomId, []);
 
         foreach ($roomToDoItems as $roomToDoItem) {
-            $steps = $roomToDoItem->getStepItemList()->_data;
+            $steps = $roomToDoItem->getStepItemList();
             foreach ($steps as $step) {
                 if (0 == strcmp((string) $step->getItemID(), (string) $itemId)) {
                     $items = [$roomToDoItem];
@@ -81,7 +81,7 @@ class StepController extends BaseController
             }
         }
 
-        $payload = $request->request->get('payload');
+        $payload = $request->request->all('payload');
         if (!isset($payload['status'])) {
             throw new Exception('new status string not provided');
         }

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -940,7 +940,7 @@ class TodoController extends BaseController
             throw new Exception('payload information not provided');
         }
 
-        $payload = $request->request->get('payload');
+        $payload = $request->request->all('payload');
         if (!isset($payload['status'])) {
             throw new Exception('new status string not provided');
         }
@@ -955,12 +955,12 @@ class TodoController extends BaseController
     /**
      * @throws Exception
      */
-    #[Route(path: '/room/{roomId}/todo/xhr/changesatatus/{itemId}', condition: 'request.isXmlHttpRequest()')]
+    #[Route(path: '/room/{roomId}/todo/xhr/changestatus/{itemId}', condition: 'request.isXmlHttpRequest()')]
     public function xhrStatusFromDetailAction($roomId, $itemId, Request $request, TodoStatusAction $action): Response
     {
         $room = $this->roomService->getRoomItem($roomId);
         $items = [$this->todoService->getTodo($itemId)];
-        $payload = $request->request->get('payload');
+        $payload = $request->request->all('payload');
         if (!isset($payload['status'])) {
             throw new Exception('new status string not provided');
         }

--- a/src/Controller/TodoController.php
+++ b/src/Controller/TodoController.php
@@ -132,7 +132,7 @@ class TodoController extends BaseController
         // or from query paramters (AJAX)
         $todoFilter = $request->get('todoFilter');
         if (!$todoFilter) {
-            $todoFilter = $request->query->get('todo_filter');
+            $todoFilter = $request->query->all('todo_filter');
         }
 
         $roomItem = $this->roomService->getRoomItem($roomId);
@@ -986,7 +986,7 @@ class TodoController extends BaseController
     ) {
         if ($selectAll) {
             if ($request->query->has('todo_filter')) {
-                $currentFilter = $request->query->get('todo_filter');
+                $currentFilter = $request->query->all('todo_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/TopicController.php
+++ b/src/Controller/TopicController.php
@@ -106,7 +106,7 @@ class TopicController extends BaseController
         // or from query paramters (AJAX)
         $topicFilter = $request->get('topicFilter');
         if (!$topicFilter) {
-            $topicFilter = $request->query->get('topic_filter');
+            $topicFilter = $request->query->all('topic_filter');
         }
 
         $roomItem = $this->getRoom($roomId);
@@ -863,7 +863,7 @@ class TopicController extends BaseController
     ) {
         if ($selectAll) {
             if ($request->query->has('topic_filter')) {
-                $currentFilter = $request->query->get('topic_filter');
+                $currentFilter = $request->query->all('topic_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -1192,7 +1192,7 @@ class UserController extends BaseController
         // or from query paramters (AJAX)
         $userFilter = $request->get('userFilter');
         if (!$userFilter) {
-            $userFilter = $request->query->get('user_filter');
+            $userFilter = $request->query->all('user_filter');
         }
 
         // $this->userManager->get()->to_array()
@@ -1519,7 +1519,7 @@ class UserController extends BaseController
     ) {
         if ($selectAll) {
             if ($request->query->has('user_filter')) {
-                $currentFilter = $request->query->get('user_filter');
+                $currentFilter = $request->query->all('user_filter');
                 $filterForm = $this->createFilterForm($roomItem);
 
                 // manually bind values from the request

--- a/templates/announcement/list.html.twig
+++ b/templates/announcement/list.html.twig
@@ -6,7 +6,7 @@
         {{ render(controller(
             'App\\Controller\\AnnouncementController::feedAction', {
                 'roomId': roomId,
-                'announcementFilter': app.request.query.get('announcement_filter')
+                'announcementFilter': app.request.query.all('announcement_filter')
             }
         ))}}
     </ul>
@@ -61,7 +61,7 @@
 
                 {# print #}
                 <li>
-                    <a href="{{ path('app_announcement_printlist', {'roomId': roomId,'announcement_filter':app.request.query.get('announcement_filter')}) }}" target="_blank" id="print">
+                    <a href="{{ path('app_announcement_printlist', {'roomId': roomId,'announcement_filter':app.request.query.all('announcement_filter')}) }}" target="_blank" id="print">
                         <i class="uk-icon-small uk-icon-print uk-icon-justify uk-visible-large"></i> {{ 'print'|trans({})|capitalize }}
                     </a>
                 </li>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -72,7 +72,7 @@
                                 {{ render(controller(
                                     'App\\Controller\\SearchController::searchFormAction', {
                                         'roomId': requestContextId,
-                                        'requestData': app.request.query.get('search') ?? app.request.query.get('search_filter')
+                                        'requestData': app.request.query.all('search') ?? app.request.query.all('search_filter')
                                     }
                                 )) }}
                             {% endif %}

--- a/templates/date/calendar.html.twig
+++ b/templates/date/calendar.html.twig
@@ -54,7 +54,7 @@
 
                                         {# print #}
                                         <li>
-                                            <a href="{{ path('app_date_printlist', {'roomId': roomId,'date_filter':app.request.query.get('date_filter')}) }}" target="_blank" id="print">
+                                            <a href="{{ path('app_date_printlist', {'roomId': roomId,'date_filter':app.request.query.all('date_filter')}) }}" target="_blank" id="print">
                                                 <i class="uk-icon-small uk-icon-print uk-icon-justify uk-visible-large"></i> {{ 'print'|trans({})|capitalize }}
                                             </a>
                                         </li>
@@ -135,7 +135,7 @@
         </div>
 
         <div id='calendar' class="uk-margin-top"
-             data-events-url='{{ path('app_date_events', {'roomId': roomId, 'dateFilter': app.request.query.get('date_filter')}) }}'
+             data-events-url='{{ path('app_date_events', {'roomId': roomId, 'dateFilter': app.request.query.all('date_filter')}) }}'
              data-events-list-url='{{ path('app_date_list', {'roomId': '<roomId>'}) }}'
              data-events-create-url='{{ path('app_date_create', {'roomId': roomId}) }}'
              data-confirm-change='{{ 'confirm change'|trans({},"date")}}'

--- a/templates/date/list.html.twig
+++ b/templates/date/list.html.twig
@@ -6,7 +6,7 @@
         {{ render(controller(
             'App\\Controller\\DateController::feedAction', {
                 'roomId': roomId,
-                'dateFilter': app.request.query.get('date_filter')
+                'dateFilter': app.request.query.all('date_filter')
             }
         ))}}
     </ul>
@@ -59,7 +59,7 @@
 
                 {# print #}
                 <li>
-                    <a href="{{ path('app_date_printlist', {'roomId': roomId,'date_filter':app.request.query.get('date_filter')}) }}" target="_blank" id="print">
+                    <a href="{{ path('app_date_printlist', {'roomId': roomId,'date_filter':app.request.query.all('date_filter')}) }}" target="_blank" id="print">
                         <i class="uk-icon-small uk-icon-print uk-icon-justify uk-visible-large"></i> {{ 'print'|trans({})|capitalize }}
                     </a>
                 </li>

--- a/templates/discussion/list.html.twig
+++ b/templates/discussion/list.html.twig
@@ -6,7 +6,7 @@
         {{ render(controller(
             'App\\Controller\\DiscussionController::feed', {
                 'roomId': roomId,
-                'discussionFilter': app.request.query.get('discussion_filter')
+                'discussionFilter': app.request.query.all('discussion_filter')
             }
         ))}}
     </ul>
@@ -60,7 +60,7 @@
 
                 {# print #}
                 <li>
-                    <a href="{{ path('app_discussion_printlist', {'roomId': roomId,'discussion_filter':app.request.query.get('discussion_filter')}) }}" target="_blank" id="print">
+                    <a href="{{ path('app_discussion_printlist', {'roomId': roomId,'discussion_filter':app.request.query.all('discussion_filter')}) }}" target="_blank" id="print">
                         <i class="uk-icon-small uk-icon-print uk-icon-justify uk-visible-large"></i> {{ 'print'|trans({})|capitalize }}
                     </a>
                 </li>

--- a/templates/group/list.html.twig
+++ b/templates/group/list.html.twig
@@ -6,7 +6,7 @@
         {{ render(controller(
             'App\\Controller\\GroupController::feedAction', {
                 'roomId': roomId,
-                'groupFilter': app.request.query.get('group_filter')
+                'groupFilter': app.request.query.all('group_filter')
              }
         ))}}
     </div>

--- a/templates/item/macros.html.twig
+++ b/templates/item/macros.html.twig
@@ -341,28 +341,31 @@
                 </div>
             </div>
         {% endif %}
-       {% if not workflowGroupArray is empty %}
-            <div class="uk-width-1-2">
-                <strong>{{ 'workflow marked as read by groups'|trans({}, "material") }}:</strong><br/>
-                {% set counter = 1 %}
-                {% for workflowGroup in workflowGroupArray %}
-                    <a href="{{ path('app_group_detail', {'roomId': item.contextId, 'itemId': workflowGroup.iid}) }}">{{workflowGroup.title|decodeHtmlEntity}}</a> ({{workflowGroup.userCount}} {{ 'of'|trans({}, "room") }} {{workflowGroup.userCountComplete}})
-                    {% if counter != workflowGroupArray|length %}, {% endif %}
-                    {% set counter = counter + 1 %}
-                {% endfor %}
-            </div>
+        {% set workflowReaderShowTo = item.contextItem.getWorkflowReaderShowTo %}
+        {% if workflowReaderShowTo is same as('all') or (workflowReaderShowTo is same as('moderator') and is_granted('MODERATOR')) %}
+            {% if not workflowGroupArray is empty %}
+                <div class="uk-width-1-2">
+                    <strong>{{ 'workflow marked as read by groups'|trans({}, "material") }}:</strong><br/>
+                    {% set counter = 1 %}
+                    {% for workflowGroup in workflowGroupArray %}
+                        <a href="{{ path('app_group_detail', {'roomId': item.contextId, 'itemId': workflowGroup.iid}) }}">{{ workflowGroup.title|decodeHtmlEntity }}</a> ({{ workflowGroup.userCount }} {{ 'of'|trans({}, "room") }} {{ workflowGroup.userCountComplete }})
+                        {% if counter != workflowGroupArray|length %}, {% endif %}
+                        {% set counter = counter + 1 %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+            {% if not workflowUserArray is empty %}
+                <div class="uk-width-1-2">
+                    <strong>{{ 'workflow marked as read by users'|trans({}, "material") }}:</strong><br/>
+                    {% set counter = 1 %}
+                    {% for workflowUser in workflowUserArray %}
+                        <a href="{{ path('app_user_detail', {'roomId': item.contextId, 'itemId': workflowUser.iid}) }}">{{ workflowUser.name }}</a>
+                        {% if counter != workflowUserArray|length %}, {% endif %}
+                        {% set counter = counter + 1 %}
+                    {% endfor %}
+                </div>
+            {% endif %}
         {% endif %}
-        {% if not workflowUserArray is empty %}
-            <div class="uk-width-1-2">
-               <strong>{{ 'workflow marked as read by users'|trans({}, "material") }}:</strong><br/>
-               {% set counter = 1 %}
-               {% for workflowUser in workflowUserArray %}
-                   <a href="{{ path('app_user_detail', {'roomId': item.contextId, 'itemId': workflowUser.iid}) }}">{{workflowUser.name}}</a>
-                    {% if counter != workflowUserArray|length %}, {% endif %}
-                    {% set counter = counter + 1 %}
-               {% endfor %}
-           </div>
-       {% endif %}
      </div>
    {% endset %}
 

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -23,7 +23,7 @@
             {#                        {{ render(controller(#}
             {#                            'App\\Controller\\SearchController::searchFormAction', {#}
             {#                                'roomId': app.request.attributes.get('roomId'),#}
-            {#                                'requestData': app.request.request.get('search') ?? app.request.query.get('search_filter')#}
+            {#                                'requestData': app.request.request.all('search') ?? app.request.query.all('search_filter')#}
             {#                            }#}
             {#                        ))}}#}
             {#                    {% endif %}#}

--- a/templates/marked/list.html.twig
+++ b/templates/marked/list.html.twig
@@ -6,7 +6,7 @@
         {{ render(controller(
             'App\\Controller\\MarkedController::feedAction', {
                 'roomId': roomId,
-                'markFilter': app.request.query.get('marked_filter')
+                'markFilter': app.request.query.all('marked_filter')
             }
         ))}}
     </ul>

--- a/templates/material/detail.html.twig
+++ b/templates/material/detail.html.twig
@@ -291,7 +291,7 @@
                         {# workflow #}
                         {% if showWorkflow and (withTrafficLight or withResubmission or withValidity or withReader) %}
                             <div id="workflow{{ material.itemId }}" class="cs-edit-section cs-toggle" data-uk-observe data-cs-edit="{editUrl: '{{ path('app_item_editworkflow', {'roomId': material.contextId, 'itemId': material.itemId}) }}', cancelEditUrl: '{{ path('app_item_canceledit', {'roomId': material.contextId, 'itemId': material.itemId}) }}' }">
-                                {{ macrosItem.workflow(material, workflowGroupArray, workflowUserArray, workflowText, workflowValidityDate, workflowResubmissionDate, workflowTitles, withTrafficLight, withResubmission, withValidity) }}
+                                {{ macrosItem.workflow(material, workflowGroupArray, workflowUserArray, workflowText, workflowValidityDate, workflowResubmissionDate, workflowTitles, withTrafficLight, withValidity, withResubmission) }}
                             </div>
                         {% endif %}
 

--- a/templates/material/detail.html.twig
+++ b/templates/material/detail.html.twig
@@ -261,7 +261,7 @@
 
                     {# title, etc. #}
                     <div class="cs-toggle" data-uk-observe>
-                        {{ macrosMaterial.title(material, modifierList, userCount, readCount, readSinceModificationCount, draft, showRating, showWorkflow, ratingArray, workflowTitles) }}
+                        {{ macrosMaterial.title(material, modifierList, userCount, readCount, readSinceModificationCount, draft, showRating, showWorkflow, withTrafficLight, ratingArray, workflowTitles) }}
                     </div>
 
                     {# description #}

--- a/templates/material/feed.html.twig
+++ b/templates/material/feed.html.twig
@@ -84,7 +84,7 @@
                     {% if showRating %}
                         {{ macros.ratingStatus(material, ratingList) }}
                     {% endif %}
-                    {% if showWorkflow %}
+                    {% if showWorkflow and withTrafficLight %}
                         {{ macros.workflowTrafficLight(material, workflowTitles) }}
                     {% endif %}
                     {{ macros.license(material) }}

--- a/templates/material/list.html.twig
+++ b/templates/material/list.html.twig
@@ -5,7 +5,7 @@
         {{ render(controller(
             'App\\Controller\\MaterialController::feedAction', {
                 'roomId': roomId,
-                'materialFilter': app.request.query.get('material_filter')
+                'materialFilter': app.request.query.all('material_filter')
             }
         ))}}
     </ul>
@@ -67,7 +67,7 @@
 
                 {# print #}
                 <li>
-                    <a href="{{ path('app_material_printlist', {'roomId': roomId,'material_filter':app.request.query.get('material_filter')}) }}" target="_blank" id="print">
+                    <a href="{{ path('app_material_printlist', {'roomId': roomId,'material_filter':app.request.query.all('material_filter')}) }}" target="_blank" id="print">
                         <i class="uk-icon-small uk-icon-print uk-icon-justify uk-visible-large"></i> {{ 'print'|trans({})|capitalize }}
                     </a>
                 </li>

--- a/templates/material/macros.html.twig
+++ b/templates/material/macros.html.twig
@@ -1,4 +1,4 @@
-{% macro title(item, modifierList, userCount, readCount, readSinceModificationCount, draft, showRating, showWorkflow, ratingArray, workflowTitles) %}
+{% macro title(item, modifierList, userCount, readCount, readSinceModificationCount, draft, showRating, showWorkflow, withTrafficLight, ratingArray, workflowTitles) %}
     {% import 'utils/macros.html.twig' as macros %}
     {% set pathName = '' %}
     {% if item.itemType == 'material' %}
@@ -10,7 +10,7 @@
     {% if userCount == 0 %}
         {% set userCount = 1 %}
     {% endif %}
-    
+
     <div id="section{{ item.itemId }}" class="cs-edit-section cs-toggle" data-cs-edit="{editUrl: '{{ path(pathName, {'roomId': item.contextId, 'itemId': item.itemId}) }}', cancelEditUrl: '{{ path('app_item_canceledit', {'roomId': item.contextId, 'itemId': item.itemId}) }}', draft: '{{ draft }}'}">
         <div class="uk-margin-left uk-margin-right uk-margin-bottom uk-position-relative">
             <div class="uk-grid uk-margin-small-bottom">
@@ -29,7 +29,7 @@
                             {% if showRating %}
                                 {{ macros.ratingStatusDetail(material, ratingArray) }}
                             {% endif %}
-                            {% if showWorkflow %}
+                            {% if showWorkflow and withTrafficLight %}
                                 {{ macros.workflowTrafficLight(material, workflowTitles) }}
                             {% endif %}
                             {{ macros.license(material) }}
@@ -41,7 +41,7 @@
                         </div>
                     {% endif %}
                     </div>
-                </div>        
+                </div>
                 <div class="uk-width-2-10">
                     {# edit #}
                     {% if is_granted('ITEM_EDIT', item.itemId) %}
@@ -54,7 +54,7 @@
             </div>
         </div>
         <div class="uk-margin-left uk-margin-right uk-position-relative">
-            <div class="uk-width-1-1 uk-padding-remove uk-margin-small-bottom">    
+            <div class="uk-width-1-1 uk-padding-remove uk-margin-small-bottom">
                 <div class="uk-grid uk-margin-small-left uk-margin-top-remove">
                     <div class="uk-width-9-10 uk-padding-remove">
                         <div class="toggle-title-{{ item.itemId }}">
@@ -147,7 +147,7 @@
                             </div>
                             <div class="uk-panel uk-margin-top">
                                 <div class="uk-grid">
-                                    <div class="uk-width-2-5">                           
+                                    <div class="uk-width-2-5">
                                         <div class="uk-clearfix">
                                             <div class="uk-align-left uk-width-1-1">
                                             {{ 'clicked since last editing'|trans({})}}: <br/>
@@ -156,22 +156,22 @@
                                                     <div class="uk-progress-bar cs-progress-bar" style="width: {{ activePercent }}%;">{{readSinceModificationCount}}</div>
                                                 </div>
                                            </div>
-                                        </div>                           
-                                    </div>                            
-                                    <div class="uk-width-1-5">                            
-                                    </div>                            
-                                    <div class="uk-width-2-5">                           
+                                        </div>
+                                    </div>
+                                    <div class="uk-width-1-5">
+                                    </div>
+                                    <div class="uk-width-2-5">
                                         <div class="uk-clearfix">
                                             <div class="uk-align-left uk-width-1-1">
                                             {{ 'clicked since creating'|trans({}) }}: <br/>
                                                 <div class="uk-progress">
                                                     {% set activePercent = (readCount/userCount*100)|round %}
                                                    <div class="uk-progress-bar cs-progress-bar" style="width: {{ activePercent }}%;">{{readCount}}</div>
-                                                </div> 
+                                                </div>
                                             </div>
-                                        </div>                           
-                                    </div>                            
-                                </div>                        
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -181,7 +181,7 @@
    </div>
 {% endmacro %}
 
-{% macro titleSave(item, modifierList, userCount, readCount, readSinceModificationCount, showRating, showWorkflow, workflowTitles) %}
+{% macro titleSave(item, modifierList, userCount, readCount, readSinceModificationCount, showRating, showWorkflow, withTrafficLight, workflowTitles) %}
     {% import 'utils/macros.html.twig' as macros %}
     <div class="uk-margin-left uk-margin-right uk-margin-bottom uk-position-relative">
             <div class="uk-grid uk-margin-small-bottom">
@@ -195,12 +195,12 @@
                                 {% include 'material/biblio.html.twig' %}
                             {% endif %}
                         </div>
-                        {%if showRating or showWorkflow%}
+                        {% if showRating or showWorkflow %}
                             <div class="uk-width-2-10  uk-text-right uk-padding-remove">
-                             {%if showRating%}
+                             {% if showRating %}
                                 {{ macros.ratingStatus(material) }}
                              {% endif %}
-                             {%if showWorkflow%}
+                             {% if showWorkflow and withTrafficLight %}
                                 {{ macros.workflowTrafficLight(material, workflowTitles) }}
                              {% endif %}
                              {{ macros.license(material) }}
@@ -212,7 +212,7 @@
                         </div>
                     {% endif %}
                 </div>
-                </div>        
+                </div>
                 <div class="uk-width-2-10 uk-text-right">
                     {# edit #}
                     {% if is_granted('ITEM_EDIT', item.itemId) %}
@@ -225,7 +225,7 @@
             </div>
         </div>
         <div class="uk-margin-left uk-margin-right uk-position-relative">
-            <div class="uk-width-1-1 uk-padding-remove uk-margin-small-bottom">    
+            <div class="uk-width-1-1 uk-padding-remove uk-margin-small-bottom">
                 <div class="uk-grid uk-margin-small-left uk-margin-top-remove">
                     <div class="uk-width-9-10 uk-padding-remove">
                         <div class="toggle-title-{{ item.itemId }}">
@@ -279,10 +279,10 @@
                                             </div>
                                         </div>
                                         <div class="uk-clearfix">
-                                            {{ 'creator'|trans({})}} 
+                                            {{ 'creator'|trans({})}}
                                         </div>
                                     </div>
-                                    <div class="uk-width-2-5">                           
+                                    <div class="uk-width-2-5">
                                         <div class="uk-clearfix">
                                             <div class="uk-margin-remove">
                                                 {% if modifierList[item.itemId] is defined %}
@@ -301,20 +301,20 @@
                                                     {% endif %}
                                                 {% endif %}
                                             </div>
-                                        </div>                           
+                                        </div>
                                         {% if modifierList[item.itemId] is defined %}
                                         {% if not modifierList[item.itemId] is empty %}
                                         <div class="uk-clearfix">
-                                            {{ 'editors'|trans({})}} 
+                                            {{ 'editors'|trans({})}}
                                         </div>
                                         {% endif %}
                                         {% endif %}
-                                    </div>                            
-                                </div>                        
+                                    </div>
+                                </div>
                             </div>
                             <div class="uk-panel uk-margin-top">
                                 <div class="uk-grid">
-                                    <div class="uk-width-2-5">                           
+                                    <div class="uk-width-2-5">
                                         <div class="uk-clearfix">
                                             <div class="uk-align-left uk-width-1-1">
                                             {{ 'clicked since last editing'|trans({})}}: <br/>
@@ -323,22 +323,22 @@
                                                     <div class="uk-progress-bar cs-progress-bar" style="width: {{ activePercent }}%;">{{readSinceModificationCount}}</div>
                                                 </div>
                                            </div>
-                                        </div>                           
-                                    </div>                            
-                                    <div class="uk-width-1-5">                            
-                                    </div>                            
-                                    <div class="uk-width-2-5">                           
+                                        </div>
+                                    </div>
+                                    <div class="uk-width-1-5">
+                                    </div>
+                                    <div class="uk-width-2-5">
                                         <div class="uk-clearfix">
                                             <div class="uk-align-left uk-width-1-1">
                                             {{ 'clicked since creating'|trans({}) }}: <br/>
                                                 <div class="uk-progress">
                                                     {% set activePercent = (readCount/userCount*100)|round %}
                                                    <div class="uk-progress-bar cs-progress-bar" style="width: {{ activePercent }}%;">{{readCount}}</div>
-                                                </div> 
+                                                </div>
                                             </div>
-                                        </div>                           
-                                    </div>                            
-                                </div>                        
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -394,7 +394,7 @@
                                 </a>
 
                                 {{ macrosUtils.fileListShort(section) }}
-                            </li>                      
+                            </li>
                         {% endfor %}
                     </ul>
                 </div>

--- a/templates/material/save.html.twig
+++ b/templates/material/save.html.twig
@@ -1,3 +1,3 @@
 {% import 'material/macros.html.twig' as macrosMaterial %}
 
-{{ macrosMaterial.titleSave(item, modifierList, userCount, readCount, readSinceModificationCount, showRating, showWorkflow, workflowTitles) }}
+{{ macrosMaterial.titleSave(item, modifierList, userCount, readCount, readSinceModificationCount, showRating, showWorkflow, withTrafficLight, workflowTitles) }}

--- a/templates/room/list_all.html.twig
+++ b/templates/room/list_all.html.twig
@@ -9,7 +9,7 @@
         {{ render(controller(
             'App\\Controller\\RoomController::feedAllAction', {
                 'roomId': roomId,
-                'roomFilter': app.request.query.get('room_filter')
+                'roomFilter': app.request.query.all('room_filter')
             }
         ))}}
     </ul>

--- a/templates/todo/list.html.twig
+++ b/templates/todo/list.html.twig
@@ -5,7 +5,7 @@
         {{ render(controller(
             'App\\Controller\\TodoController::feedAction', {
                 'roomId': roomId,
-                'todoFilter': app.request.query.get('todo_filter')
+                'todoFilter': app.request.query.all('todo_filter')
             }
         ))}}
     </ul>

--- a/templates/topic/list.html.twig
+++ b/templates/topic/list.html.twig
@@ -6,7 +6,7 @@
         {{ render(controller(
             'App\\Controller\\TopicController::feedAction', {
                 'roomId': roomId,
-                'topicFilter': app.request.query.get('topic_filter')
+                'topicFilter': app.request.query.all('topic_filter')
             }
         ))}}
     </div>

--- a/templates/user/list.html.twig
+++ b/templates/user/list.html.twig
@@ -7,7 +7,7 @@
             {{ render(controller(
                 'App\\Controller\\UserController::feedAction', {
                     'roomId': roomId,
-                    'userFilter': app.request.query.get('user_filter')
+                    'userFilter': app.request.query.all('user_filter')
                 }
             )) }}
         </ul>
@@ -20,7 +20,7 @@
             {{ render(controller(
                 'App\\Controller\\UserController::gridAction', {
                     'roomId': roomId,
-                    'userFilter': app.request.query.get('user_filter')
+                    'userFilter': app.request.query.all('user_filter')
                 }
             )) }}
         </div>
@@ -67,7 +67,7 @@
         {% block dropdown %}
             <ul class="uk-nav uk-nav-dropdown uk-list-striped">
                 <li>
-                    <a href="{{ path('app_user_printlist', {'roomId': roomId,'user_filter':app.request.query.get('user_filter')}) }}" target="_blank" id="print">
+                    <a href="{{ path('app_user_printlist', {'roomId': roomId,'user_filter':app.request.query.all('user_filter')}) }}" target="_blank" id="print">
                         <i class="uk-icon-small uk-icon-print uk-icon-justify uk-visible-large"></i> {{ 'print'|trans({})|capitalize }}
                     </a>
                 </li>


### PR DESCRIPTION
PR for [#4918](https://projects.effective-webwork.de/projects/commsy/work_packages/4918/activity?query_id=350): If the reader view is activated in a project room's settings, this shouldn't cause the status view to get displayed in an material item's detail view (if it is currently deactivated).

Additional fixes:
- related to reader view, in the workflow section of a material item's detail view:
  - activating the "Resubmission" option incorrectly caused the label "2nd resubmission at" to get displayed
  -  the "Reader view only for moderators" option did not have any effect
- fixes of exceptions which occurred for:
  - "Restrict list" functionality in rubric sidebars and subsequent feed reloading
  - actions "Assign categories" & "Assign hashtags"
  - list action "Mark as read" (when using "Select all")
  - detail actions "Mark as read" & "Mark as not read", plus some other detail actions
  - action "Print"
