### PR TITLE
5154 the time pulse option "continuous" rules out any individual time pulse choices

### DIFF
--- a/src/Form/DataTransformer/GeneralSettingsTransformer.php
+++ b/src/Form/DataTransformer/GeneralSettingsTransformer.php
@@ -104,16 +104,16 @@ class GeneralSettingsTransformer extends AbstractTransformer
             if ($roomItem->isProjectRoom() || $roomItem->isGroupRoom()) {
                 if ($roomItem->isContinuous()) {
                     $roomData['time_pulses'][] = 'cont';
-                }
+                } else {
+                    $roomTimeList = $roomItem->getTimeList();
 
-                $roomTimeList = $roomItem->getTimeList();
+                    if (!$roomTimeList->isEmpty()) {
+                        $roomTimeItem = $roomTimeList->getFirst();
+                        while ($roomTimeItem) {
+                            $roomData['time_pulses'][] = $roomTimeItem->getItemID();
 
-                if (!$roomTimeList->isEmpty()) {
-                    $roomTimeItem = $roomTimeList->getFirst();
-                    while ($roomTimeItem) {
-                        $roomData['time_pulses'][] = $roomTimeItem->getItemID();
-
-                        $roomTimeItem = $roomTimeList->getNext();
+                            $roomTimeItem = $roomTimeList->getNext();
+                        }
                     }
                 }
             }

--- a/src/Form/Type/Context/ProjectType.php
+++ b/src/Form/Type/Context/ProjectType.php
@@ -25,6 +25,8 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProjectType extends AbstractType
@@ -72,6 +74,9 @@ class ProjectType extends AbstractType
                 'multiple' => true,
                 'label' => $options['timesDisplay'],
                 'translation_domain' => 'room',
+                'constraints' => [
+                    new Assert\Callback($this->validateTimePulses(...)),
+                ],
             ]);
         }
         $builder->add('community_rooms', ChoiceType::class, [
@@ -135,5 +140,14 @@ class ProjectType extends AbstractType
             ->setRequired(['types', 'templates', 'preferredChoices', 'timesDisplay', 'times', 'linkCommunitiesMandantory', 'roomCategories', 'linkRoomCategoriesMandatory'])
             ->setDefaults(['translation_domain' => 'form'])
         ;
+    }
+
+    public function validateTimePulses(array $selectedTimePulses, ExecutionContextInterface $context): void
+    {
+        if (count($selectedTimePulses) > 1 && in_array('cont', $selectedTimePulses)) {
+            $context->buildViolation('Continuous can only be specified without any other time pulse choices.')
+                ->atPath('time_interval')
+                ->addViolation();
+        }
     }
 }

--- a/src/Form/Type/GeneralSettingsType.php
+++ b/src/Form/Type/GeneralSettingsType.php
@@ -29,7 +29,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class GeneralSettingsType extends AbstractType
@@ -58,7 +59,7 @@ class GeneralSettingsType extends AbstractType
         $roomItem = $roomManager->getItem($options['roomId']);
 
         $builder
-            ->add('title', TextType::class, ['constraints' => [new NotBlank()], 'attr' => ['style' => 'width: 250px;']])
+            ->add('title', TextType::class, ['constraints' => [new Assert\NotBlank()], 'attr' => ['style' => 'width: 250px;']])
             ->add('language', ChoiceType::class, ['choices' => ['User preferences' => 'user', 'German' => 'de', 'English' => 'en'], 'empty_data' => 'user', 'attr' => ['style' => 'width: 250px;'], 'help' => 'Room language tip'])
             ->add('access_check', ChoiceType::class, ['required' => false, 'choices' => ['Never' => 'never', 'Always' => 'always', 'Code' => 'withcode']])
             ->add('access_code', TextType::class, ['required' => false, 'attr' => ['style' => 'display: none;'], 'label' => false])
@@ -148,6 +149,9 @@ class GeneralSettingsType extends AbstractType
                         'required' => false,
                         'choices' => $this->getTimeChoices(),
                         'multiple' => true,
+                        'constraints' => [
+                            new Assert\Callback($this->validateTimePulses(...)),
+                        ],
                     ])
                 ;
             }
@@ -226,5 +230,14 @@ class GeneralSettingsType extends AbstractType
         }
 
         return $results;
+    }
+
+    public function validateTimePulses(array $selectedTimePulses, ExecutionContextInterface $context): void
+    {
+        if (count($selectedTimePulses) > 1 && in_array('cont', $selectedTimePulses)) {
+            $context->buildViolation('Continuous can only be specified without any other time pulse choices.')
+                ->atPath('time_pulses')
+                ->addViolation();
+        }
     }
 }

--- a/translations/validators.de.xlf
+++ b/translations/validators.de.xlf
@@ -225,6 +225,12 @@
                 <target>Ihre Auswahl darf nicht identisch sein.</target>
             </trans-unit>
 
+            <!-- room settings -->
+            <trans-unit id="violation_room_settings_general_time_pulses">
+                <source>Continuous can only be specified without any other time pulse choices.</source>
+                <target>Die Option "kontinuierlich" kann nur verwendet werden, wenn keine anderen Zeittakte angegeben wurden.</target>
+            </trans-unit>
+
             <!-- signup -->
             <trans-unit id="signup-regex-mail">
                 <source>signup-regex-mail</source>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -225,6 +225,12 @@
                 <target>Your selection must differ.</target>
             </trans-unit>
 
+            <!-- room settings -->
+            <trans-unit id="violation_room_settings_general_time_pulses">
+                <source>Continuous can only be specified without any other time pulse choices.</source>
+                <target>The "continuous" option can only be specified without any other time pulse choices.</target>
+            </trans-unit>
+
             <!-- signup -->
             <trans-unit id="signup-regex-mail">
                 <source>signup-regex-mail</source>


### PR DESCRIPTION
For a room, one can either specify "continuous" as a time pulse option, or some individual time pulses, but not both.

PR for [#5154](https://projects.effective-webwork.de/projects/commsy/work_packages/5154)
