### PR TITLE
#5337 Avoids a "DirectoryNotFoundException" when accessing a room's room profile

### DIFF
--- a/src/Files/ProfileHelper.php
+++ b/src/Files/ProfileHelper.php
@@ -15,6 +15,7 @@ namespace App\Files;
 
 use App\Entity\Account;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 class ProfileHelper
@@ -31,6 +32,10 @@ class ProfileHelper
         }
 
         $fileDirectory = $this->uploadDir . $account->getId();
+        $filesystem = new Filesystem();
+        if (!$filesystem->exists($fileDirectory)) {
+            return null;
+        }
 
         $finder = new Finder();
         $finder


### PR DESCRIPTION
PR for [#5337](https://projects.effective-webwork.de/projects/commsy/work_packages/5337)