### PR TITLE
#5339 Fix filtering of users from within portal config

### DIFF
--- a/src/Filter/AccountFilterType.php
+++ b/src/Filter/AccountFilterType.php
@@ -93,7 +93,7 @@ class AccountFilterType extends AbstractType
                         // Members
                         1 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('r.itemId IS NOT NULL')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('r.deleter IS NULL')
@@ -108,28 +108,28 @@ class AccountFilterType extends AbstractType
                             ->setParameter('locked', true),
                         // Requesting
                         3 => $qb
-                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.contextId = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
+                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.context = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
                             ->andWhere($expr->eq('pu.status', ':status'))
                             ->setParameter('status', 1),
                         // User
                         4 => $qb
-                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.contextId = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
+                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.context = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
                             ->andWhere($expr->eq('pu.status', ':status'))
                             ->setParameter('status', 2),
                         // Moderator
                         5 => $qb
-                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.contextId = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
+                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.context = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
                             ->andWhere($expr->eq('pu.status', ':status'))
                             ->setParameter('status', 3),
                         // Contact
                         6 => $qb
-                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.contextId = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
+                            ->innerJoin(User::class, 'pu', Join::WITH, 'pu.context = a.contextId AND pu.userId = a.username AND pu.authSource = a.authSource')
                             ->andWhere($expr->eq('pu.isContact', ':contact'))
                             ->setParameter('contact', true),
                         // Community workspace moderator
                         7 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('ru.status = :status')
                             ->andWhere('r.deleter IS NULL')
@@ -141,7 +141,7 @@ class AccountFilterType extends AbstractType
                         // Community workspace contact
                         8 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('ru.isContact = :contact')
                             ->andWhere('r.deleter IS NULL')
@@ -153,7 +153,7 @@ class AccountFilterType extends AbstractType
                         // Project workspace moderator
                         9 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('ru.status = :status')
                             ->andWhere('r.deleter IS NULL')
@@ -165,7 +165,7 @@ class AccountFilterType extends AbstractType
                         // project workspace contact
                         10 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('ru.isContact = :contact')
                             ->andWhere('r.deleter IS NULL')
@@ -177,7 +177,7 @@ class AccountFilterType extends AbstractType
                         // moderator of any workspace
                         11 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.status = :status')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('r.deleter IS NULL')
@@ -187,7 +187,7 @@ class AccountFilterType extends AbstractType
                         // contact of any workspace
                         12 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->innerJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.isContact = :contact')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->andWhere('r.deleter IS NULL')
@@ -197,7 +197,7 @@ class AccountFilterType extends AbstractType
                         // no workspace membership
                         13 => $qb
                             ->leftJoin(User::class, 'ru', Join::WITH, 'ru.userId = a.username AND ru.authSource = a.authSource')
-                            ->leftJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.contextId')
+                            ->leftJoin(Room::class, 'r', Join::WITH, 'r.itemId = ru.context')
                             ->andWhere('ru.isNotDeleted = :notDeleted')
                             ->groupBy('ru.userId')
                             ->having('COUNT(ru.userId) = 2')


### PR DESCRIPTION
PR for [#5339](https://projects.effective-webwork.de/projects/commsy/work_packages/5339)

TODO: Filtering for "No workspaces participation" ("Keine Raumteilnahme") has an additional query issue. 