### PR TITLE
Sicherheits-Backport nach 10.4

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -1024,7 +1024,12 @@ class UserController extends BaseController
         ]);
     }
 
+    // Mirrors the guards on detail(): the print variant exposes the same data,
+    // and ITEM_SEE resolves against the item itself, so a room id in the path
+    // that does not belong to the entry is rejected as well.
     #[Route(path: '/room/{roomId}/user/{itemId}/print')]
+    #[IsGranted('ITEM_SEE', subject: 'itemId')]
+    #[IsGranted('RUBRIC_USER')]
     public function print(
         PrintService $printService,
         int $roomId,

--- a/src/Repository/AccountsRepository.php
+++ b/src/Repository/AccountsRepository.php
@@ -44,21 +44,31 @@ class AccountsRepository extends ServiceEntityRepository
     }
 
     /**
+     * Looks up an account by username and auth source, scoped to a portal
+     * if one is given. The server-context root account and its auth source
+     * have no portal binding (portal_id IS NULL) — pass $portal=null in
+     * that case to find it.
+     *
      * @throws NonUniqueResultException
      */
-    public function findOneByCredentials(string $username, Portal $portal, AuthSource $authSource): ?Account
+    public function findOneByCredentials(string $username, ?Portal $portal, AuthSource $authSource): ?Account
     {
-        return $this->createQueryBuilder('a')
+        $qb = $this->createQueryBuilder('a')
             ->where('a.username = :username')
             ->andWhere('a.authSource = :authSource')
-            ->andWhere('a.portal = :portal')
             ->setParameters(new ArrayCollection([
                 new Parameter('username', $username),
-                new Parameter('portal', $portal),
                 new Parameter('authSource', $authSource),
-            ]))
-            ->getQuery()
-            ->getOneOrNullResult();
+            ]));
+
+        if ($portal !== null) {
+            $qb->andWhere('a.portal = :portal')
+                ->setParameter('portal', $portal);
+        } else {
+            $qb->andWhere('a.portal IS NULL');
+        }
+
+        return $qb->getQuery()->getOneOrNullResult();
     }
 
     public function findByEmailAndPortalId(string $email, int $portalId)

--- a/src/Security/Authorization/Voter/ItemVoter.php
+++ b/src/Security/Authorization/Voter/ItemVoter.php
@@ -28,6 +28,7 @@ use App\WOPI\Discovery\DiscoveryService;
 use cs_environment;
 use cs_item;
 use cs_privateroom_item;
+use cs_room_item;
 use cs_user_item;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -109,6 +110,40 @@ class ItemVoter extends Voter
                     }
                 }
             }
+        }
+
+        // ITEM_ENTER WORKAROUND — NOT A FIX.
+        //
+        // The block above resolves a numeric subject through the legacy
+        // items path first (ItemService->getTypedItem) and only falls back
+        // to PortalRepository if that returns null. Portal ids and
+        // items.item_id share the same numeric AUTO_INCREMENT range, so
+        // a row in `items` (e.g. type='user' or type='server') can shadow
+        // a portal with the same id. For ITEM_ENTER, where the subject is
+        // always meant to be a room or portal, this leaks the wrong
+        // subject into canEnter and surfaces as "Call to undefined method
+        // isPrivateRoom()" or a 302 redirect to a fallback URL.
+        //
+        // The PROPER fix is to stop resolving portals through the legacy
+        // items table at all: portals already live in the `portal` table
+        // as Doctrine entities, and PortalRepository is the canonical
+        // source. To get there we need to (a) standardize on Portal
+        // entities (or a typed wrapper) for portal subjects across all
+        // voter callers, and (b) drop the items-based portal lookup in
+        // ItemService / cs_environment::getCurrentContextItem. That is a
+        // larger migration tracked separately.
+        //
+        // Until then, force a portal lookup for ENTER when the resolved
+        // item is not actually a room — this keeps ENTER deterministic
+        // without changing any callers.
+        if (
+            self::ENTER === $attribute
+            && $item !== null
+            && !$item instanceof cs_room_item
+            && !$item instanceof PortalProxy
+        ) {
+            $portal = $this->entityManager->getRepository(Portal::class)->find($subject);
+            $item = $portal ? new PortalProxy($portal, $this->legacyEnvironment) : null;
         }
 
         $currentUser = $this->legacyEnvironment->getCurrentUserItem();

--- a/src/Security/Authorization/Voter/ItemVoter.php
+++ b/src/Security/Authorization/Voter/ItemVoter.php
@@ -27,6 +27,7 @@ use App\Utils\UserService;
 use App\WOPI\Discovery\DiscoveryService;
 use cs_environment;
 use cs_item;
+use cs_privateroom_item;
 use cs_user_item;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -271,7 +272,21 @@ class ItemVoter extends Voter
     private function canEnter(cs_item|PortalProxy $item, $currentUser, $user): bool
     {
         if ($item->isPrivateRoom()) {
-            return true;
+            // A private room is a single user's personal dashboard. Only its
+            // owner may enter it. Without this check anyone who knows (or
+            // guesses) a private-room id could reach that user's dashboard
+            // and, via /room/{id}/all, the portal-wide room list — even as a
+            // guest. Identity is keyed by account_id (see cs_user_item).
+            // (The root account is already short-circuited in voteOnAttribute.)
+            if (!$item instanceof cs_privateroom_item || !$user instanceof Account) {
+                return false;
+            }
+
+            $owner = $item->getOwnerUserItem();
+
+            return $owner !== null
+                && $owner->getAccountID() !== null
+                && $owner->getAccountID() === $user->getId();
         }
 
         if ($item->isPortal()) {

--- a/src/Security/Authorization/Voter/SwitchToUserVoter.php
+++ b/src/Security/Authorization/Voter/SwitchToUserVoter.php
@@ -14,6 +14,7 @@
 namespace App\Security\Authorization\Voter;
 
 use App\Entity\Account;
+use App\Entity\Portal;
 use App\Utils\UserService;
 use cs_user_item;
 use DateTimeImmutable;
@@ -45,10 +46,14 @@ class SwitchToUserVoter extends Voter
      */
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
-        /** @var Account $account */
         $account = $token->getUser();
 
-        if (!$account instanceof UserInterface || !$subject instanceof UserInterface) {
+        // Narrowed to Account, not UserInterface: everything below reads the
+        // username or the portal off these two, and only Account carries them.
+        // The previous UserInterface guard sat under a `@var Account` docblock
+        // and would have run into an undefined getUsername() had the token ever
+        // held anything else.
+        if (!$account instanceof Account || !$subject instanceof Account) {
             return false;
         }
 
@@ -56,10 +61,47 @@ class SwitchToUserVoter extends Voter
             return true;
         }
 
+        // Taking over an account is a moderation act, so it takes moderation of
+        // the portal the target belongs to. Without this the check below stood
+        // alone, and since getCanImpersonateAnotherUser() is an opt-out that
+        // nobody sets, EVERY authenticated member passed it — on any url,
+        // because the switch_user listener runs firewall-wide and not just on
+        // the portal settings route.
+        //
+        // The target must have a portal, which is also what puts root out of
+        // reach for good: the server-context root account has none, and
+        // UserProvider hands it out before any portal scoping. Becoming root
+        // requires logging in as root.
+        //
+        // 10.5 delegates all of this to UserVoter::PORTAL_MODERATOR. That is
+        // not available here: on this branch the attribute ignores its subject
+        // (so it would not bind the target's portal), it casts the subject with
+        // intval() before dispatching (so a Portal entity is not a valid
+        // argument at all), and it reads the actor from the legacy
+        // currentUserItem rather than from the token — which this voter cannot
+        // rely on, running inside the firewall listener. The rule is therefore
+        // spelled out here, off the two accounts and the actor's portal user
+        // item that is fetched below anyway.
+        $actorPortal = $account->getPortal();
+        $targetPortal = $subject->getPortal();
+
+        if (!$actorPortal instanceof Portal
+            || !$targetPortal instanceof Portal
+            || $actorPortal->getId() !== $targetPortal->getId()
+            || null !== $targetPortal->getDeletionDate()
+        ) {
+            return false;
+        }
+
         /** @var cs_user_item $portalUser */
         $portalUser = $this->userService->getPortalUser($account);
 
-        // check if the user is allowed to impersonate by flag
+        if (!$portalUser->isModerator()) {
+            return false;
+        }
+
+        // A moderator holds the right by default; it can be withdrawn for
+        // individuals, optionally with a deadline.
         if ($portalUser->getCanImpersonateAnotherUser()) {
             // check if the impersonate grant is expired
             $now = new DateTimeImmutable();

--- a/templates/utils/macros.html.twig
+++ b/templates/utils/macros.html.twig
@@ -273,8 +273,13 @@
     </a>
 {% endmacro %}
 
+{# user may be null: creator_id is nullable and unset on system-created
+   accounts. That is not the same as a deleted person, so it gets a dash
+   rather than the "deleted person" label. #}
 {% macro userFullname(user) %}
-    {% if not user.isDeleted %}
+    {% if user is null %}
+        -
+    {% elseif not user.isDeleted %}
         {{user.Fullname}}
     {% else %}
         {{ "deleted person"|trans({}, 'user')}}

--- a/tests/Application/Controller/PrintRoutesAuthorizationTest.php
+++ b/tests/Application/Controller/PrintRoutesAuthorizationTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/*
+ * This file is part of CommSy.
+ *
+ * (c) Matthias Finck, Dirk Fust, Oliver Hankel, Iver Jackewitz, Michael Janneck,
+ * Martti Jeenicke, Detlev Krause, Irina L. Marinescu, Timo Nolte, Bernd Pape,
+ * Edouard Simon, Monique Strauss, Jose Mauel Gonzalez Vazquez, Johannes Schultze
+ */
+
+namespace Tests\Application\Controller;
+
+use App\Entity\Account;
+use App\Entity\Room;
+use App\Entity\User;
+use Knp\Snappy\Pdf;
+use Tests\Application\AbstractApplicationTestCase;
+use Tests\Factory\AccountFactory;
+use Tests\Factory\RoomFactory;
+use Tests\Factory\RoomUserFactory;
+use Tests\Story\RoomWithMemberStory;
+use Zenstruck\Foundry\Attribute\WithStory;
+
+/**
+ * Pins that the person print route enforces the same access rules as the detail
+ * view it mirrors. The detail assertions are the control: they show the voter
+ * working, so a passing detail check next to a failing print check isolates the
+ * print route as the gap.
+ *
+ * Reduced against the 10.5 original, which walks every rubric: the rubric
+ * factories (Announcement, Dates, Discussion, Label, Material, Todo) do not
+ * exist on this branch. Personal data is the part that mattered here anyway —
+ * the print route was the only one of the two without any guard.
+ */
+#[WithStory(RoomWithMemberStory::class)]
+class PrintRoutesAuthorizationTest extends AbstractApplicationTestCase
+{
+    private Account $member;
+    private Account $outsider;
+    private Room $room;
+    private User $roomUser;
+    private int $roomId;
+
+    private int $foreignUserItemId;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->member = RoomWithMemberStory::get('account');
+        $this->room = RoomWithMemberStory::get('room');
+        $this->roomUser = RoomWithMemberStory::get('roomUser');
+        $this->roomId = $this->room->getItemId();
+
+        $pdf = $this->createMock(Pdf::class);
+        $pdf->method('getOutputFromHtml')->willReturn('%PDF-1.4 stub');
+        static::getContainer()->set('knp_snappy.pdf', $pdf);
+
+        // A second account in the same portal that is not a member of the room.
+        // The portal is not passed on purpose: AccountFactory only wires the
+        // auth source when it resolves the portal itself.
+        $this->outsider = AccountFactory::createOne([
+            'activityState' => Account::ACTIVITY_ACTIVE,
+            'locked' => false,
+        ]);
+
+        $this->assertSame(
+            $this->member->getPortal()->getId(),
+            $this->outsider->getPortal()->getId(),
+            'outsider must live in the same portal, otherwise this tests the wrong boundary'
+        );
+
+        // Must run after the outsider exists: the foreign room holds their
+        // person entry, not the member's, or the member would legitimately be
+        // allowed to see it and the check below would prove nothing.
+        $this->createForeignRoom();
+    }
+
+    /**
+     * Control: the guarded detail route must reject a non-member.
+     */
+    public function testOutsiderIsDeniedOnUserDetailView(): void
+    {
+        $this->loginAsOutsider();
+
+        $this->client->request('GET', "/room/$this->roomId/user/{$this->roomUser->getItemId()}");
+
+        $this->assertAccessDenied('non-member must not see the person detail view');
+    }
+
+    public function testOutsiderIsDeniedOnUserPrint(): void
+    {
+        $this->loginAsOutsider();
+
+        $this->client->request('GET', "/room/$this->roomId/user/{$this->roomUser->getItemId()}/print");
+
+        $this->assertAccessDenied('non-member must not print personal data');
+    }
+
+    public function testAnonymousGetsNoContentFromUserPrint(): void
+    {
+        $itemId = $this->roomUser->getItemId();
+
+        $this->client->request('GET', "/room/$this->roomId/user/$itemId/print");
+
+        $this->assertAccessDenied('anonymous request must not receive personal data');
+    }
+
+    public function testOutsiderIsDeniedOnUserPrintList(): void
+    {
+        $this->loginAsOutsider();
+
+        $this->client->request('GET', "/room/$this->roomId/user/print/none");
+
+        $this->assertAccessDenied('non-member must not print the person list');
+    }
+
+    /**
+     * The room id in the URL must belong to the requested item. Otherwise any
+     * room the caller may enter can be used as a passe-partout for entries
+     * living somewhere else.
+     *
+     * Browsed through a room created here rather than through the story room,
+     * whose type RoomFactory picks at random: the rule only holds outside
+     * community rooms, and the next test pins the other half.
+     */
+    public function testRoomIdMustMatchTheRequestedItem(): void
+    {
+        $projectRoomId = $this->createRoomWithMember('project');
+
+        $this->loginAsMember();
+
+        $this->client->request('GET', "/room/$projectRoomId/user/$this->foreignUserItemId/print");
+
+        $this->assertAccessDenied(
+            'an item from another room must not be printable through a room the caller may enter'
+        );
+    }
+
+    /**
+     * Characterization, not an endorsement: in a community room a logged-in
+     * member sees every person of the portal, including one whose entry lives
+     * in a room they are no member of. `cs_user_item::maySee()` grants on
+     * `isVisibleForLoggedIn()`, which is hard-true. The print route inherits
+     * that, exactly like the detail view it mirrors.
+     *
+     * Pinned so the ITEM_SEE guard added alongside cannot be mistaken for a
+     * tighter rule than it is, and so a later change to that visibility rule
+     * shows up here rather than silently.
+     */
+    public function testCommunityRoomLetsAMemberPrintAnyPersonOfThePortal(): void
+    {
+        $communityRoomId = $this->createRoomWithMember('community');
+
+        $this->loginAsMember();
+
+        $this->client->request('GET', "/room/$communityRoomId/user/$this->foreignUserItemId/print");
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    private function loginAsMember(): void
+    {
+        $this->loginAsUser(
+            $this->member->getPortal()->getId(),
+            $this->member->getUsername(),
+            $this->member->getPlainPassword()
+        );
+    }
+
+    private function loginAsOutsider(): void
+    {
+        $this->loginAsUser(
+            $this->outsider->getPortal()->getId(),
+            $this->outsider->getUsername(),
+            $this->outsider->getPlainPassword()
+        );
+    }
+
+    /**
+     * A non-member is turned away with a redirect to the room request page, not
+     * with 403 — only the server context answers 403. What matters is that no
+     * content comes back.
+     *
+     * A 5xx is explicitly not a denial: a template crashing before it finishes
+     * would otherwise count as "protected" and hide a missing check.
+     */
+    private function assertAccessDenied(string $message): void
+    {
+        $status = $this->client->getResponse()->getStatusCode();
+
+        $this->assertContains(
+            $status,
+            [301, 302, 401, 403],
+            $message." (got HTTP $status)"
+        );
+    }
+
+    /**
+     * A room of the given type in the member's portal, with the member joined,
+     * so it can serve as the browsing context.
+     */
+    private function createRoomWithMember(string $type): int
+    {
+        $room = RoomFactory::createOne([
+            'type' => $type,
+            'contextId' => $this->member->getPortal()->getId(),
+            'portal' => $this->member->getPortal(),
+        ]);
+
+        RoomUserFactory::createOne([
+            'account' => $this->member,
+            'room' => $room,
+        ]);
+
+        return $room->getItemId();
+    }
+
+    /**
+     * A second room holding a person, used to check that the room id in the URL
+     * is validated against the item.
+     */
+    private function createForeignRoom(): void
+    {
+        $foreignRoom = RoomFactory::createOne([
+            'contextId' => $this->member->getPortal()->getId(),
+            'portal' => $this->member->getPortal(),
+        ]);
+
+        $foreignUser = RoomUserFactory::createOne([
+            'account' => $this->outsider,
+            'room' => $foreignRoom,
+        ]);
+
+        $this->foreignUserItemId = $foreignUser->getItemId();
+    }
+}

--- a/tests/Application/PrivateRoomEnterTest.php
+++ b/tests/Application/PrivateRoomEnterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of CommSy.
+ *
+ * (c) Matthias Finck, Dirk Fust, Oliver Hankel, Iver Jackewitz, Michael Janneck,
+ * Martti Jeenicke, Detlev Krause, Irina L. Marinescu, Timo Nolte, Bernd Pape,
+ * Edouard Simon, Monique Strauss, Jose Mauel Gonzalez Vazquez, Johannes Schultze
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Application;
+
+use App\Entity\Account;
+use Doctrine\ORM\EntityManagerInterface;
+use Tests\Factory\AccountFactory;
+use Tests\Factory\AuthSourceLocalFactory;
+use Tests\Factory\PortalFactory;
+
+/**
+ * A private room is a single user's personal dashboard. ItemVoter::canEnter()
+ * used to return true for ANY private room, and RoomController carries
+ * #[IsGranted('ITEM_ENTER', subject: 'roomId')] on the class, so knowing a
+ * foreign private-room id was enough to open that dashboard and — via
+ * /room/{id}/all — the portal-wide room list.
+ *
+ * Exercised through the real routes rather than against the voter directly:
+ * the owner check reads the account off the token while the surrounding voter
+ * still works from the legacy currentUserItem that LegacySubscriber primes per
+ * request, and only a real request wires both up the way production does.
+ */
+final class PrivateRoomEnterTest extends AbstractApplicationTestCase
+{
+    public function testOwnerCanEnterOwnPrivateRoom(): void
+    {
+        ['portal' => $portal, 'owner' => $owner] = $this->createScenario();
+        $portalId = $portal->getId();
+
+        $this->loginAsUser($portalId, $owner->getUsername(), $owner->getPlainPassword());
+
+        $this->client->request('GET', '/room/'.$this->privateRoomIdOf($owner).'/all');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * Denial shows up as a redirect, not as 403: App\Security\AccessDeniedHandler
+     * bounces a non-XHR request to the requested room's detail page. Asserting
+     * that target rather than "not 200" keeps the case from passing on any
+     * unrelated redirect.
+     */
+    public function testStrangerCannotEnterAForeignPrivateRoom(): void
+    {
+        ['portal' => $portal, 'owner' => $owner, 'stranger' => $stranger] = $this->createScenario();
+        $portalId = $portal->getId();
+        $privateRoomId = $this->privateRoomIdOf($owner);
+
+        $this->loginAsUser($portalId, $stranger->getUsername(), $stranger->getPlainPassword());
+
+        $this->client->request('GET', "/room/{$privateRoomId}/all");
+
+        self::assertResponseRedirects(
+            "/portal/{$portalId}/room/{$privateRoomId}",
+            null,
+            'a member of the same portal must not reach another account\'s private room',
+        );
+    }
+
+    /**
+     * The guest case is the reason this counts as a leak rather than a mere
+     * over-permission: no account at all was needed. Here the firewall's entry
+     * point answers, so the bounce goes to the login page.
+     */
+    public function testGuestCannotEnterAPrivateRoom(): void
+    {
+        ['portal' => $portal, 'owner' => $owner] = $this->createScenario();
+
+        $this->client->request('GET', '/room/'.$this->privateRoomIdOf($owner).'/all');
+
+        self::assertResponseRedirects('/login/'.$portal->getId());
+    }
+
+    /**
+     * @return array{portal: mixed, owner: mixed, stranger: mixed}
+     */
+    private function createScenario(): array
+    {
+        $localSource = AuthSourceLocalFactory::createOne(['enabled' => true, 'default' => true]);
+        $portal = PortalFactory::createOne(['authSources' => [$localSource]]);
+
+        // AccountFactory persists through AccountCreatorFacade, which lets the
+        // legacy user manager create the account's private room — so this is
+        // the real room, not a hand-built one.
+        $owner = AccountFactory::createOne([
+            'portal' => $portal,
+            'authSource' => $localSource,
+            'username' => 'room.owner',
+            'activityState' => Account::ACTIVITY_ACTIVE,
+            'locked' => false,
+        ]);
+
+        $stranger = AccountFactory::createOne([
+            'portal' => $portal,
+            'authSource' => $localSource,
+            'username' => 'the.stranger',
+            'activityState' => Account::ACTIVITY_ACTIVE,
+            'locked' => false,
+        ]);
+
+        return ['portal' => $portal, 'owner' => $owner, 'stranger' => $stranger];
+    }
+
+    /**
+     * Resolved over the owning user row instead of the room table alone, so the
+     * test cannot accidentally pick up another account's private room.
+     */
+    private function privateRoomIdOf(Account $account): int
+    {
+        $roomId = static::getContainer()->get(EntityManagerInterface::class)
+            ->getConnection()
+            ->fetchOne(
+                'SELECT r.item_id FROM room r
+                   JOIN user u ON u.context_id = r.item_id
+                  WHERE r.type = ? AND u.account_id = ?',
+                ['privateroom', $account->getId()]
+            );
+
+        self::assertNotFalse($roomId, 'the account has no private room — fixture setup failed');
+
+        return (int) $roomId;
+    }
+}

--- a/tests/Application/SwitchUserTest.php
+++ b/tests/Application/SwitchUserTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of CommSy.
+ *
+ * (c) Matthias Finck, Dirk Fust, Oliver Hankel, Iver Jackewitz, Michael Janneck,
+ * Martti Jeenicke, Detlev Krause, Irina L. Marinescu, Timo Nolte, Bernd Pape,
+ * Edouard Simon, Monique Strauss, Jose Mauel Gonzalez Vazquez, Johannes Schultze
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Application;
+
+use App\Entity\Account;
+use Tests\Factory\AccountFactory;
+use Tests\Factory\AuthSourceLocalFactory;
+use Tests\Factory\PortalFactory;
+
+/**
+ * Access-control tests for Symfony's switch_user listener, which is enabled on
+ * the main firewall with `role: CAN_SWITCH_USER` and therefore reacts to a
+ * `?_switch_user=` parameter on ANY url under that firewall — not only on the
+ * portal settings take-over route.
+ *
+ * These tests answer the question a voter test cannot: does the parameter
+ * actually change the authenticated identity end to end?
+ */
+final class SwitchUserTest extends AbstractApplicationTestCase
+{
+    /**
+     * The take-over path a portal moderator is meant to use, exercised without
+     * the settings route: the parameter alone switches identity.
+     */
+    public function testSwitchUserParameterChangesTheAuthenticatedIdentity(): void
+    {
+        ['portal' => $portal, 'actor' => $actor, 'target' => $target] = $this->createScenario();
+        $portalId = $portal->getId();
+
+        $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
+
+        $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user={$target->getUsername()}");
+
+        self::assertSame(
+            $target->getUsername(),
+            $this->authenticatedUsername(),
+            'the _switch_user parameter is honoured outside the portal settings route',
+        );
+    }
+
+    /**
+     * Characterization of a permissive default, NOT an endorsement.
+     *
+     * `cs_user_item::getCanImpersonateAnotherUser()` is an opt-OUT
+     * (`!_issetExtra('DEACTIVATE_LOGIN_AS')`), and SwitchToUserVoter checks
+     * nothing else — no moderator status, no portal-moderation right. A plain
+     * portal member therefore passes CAN_SWITCH_USER, and because the listener
+     * runs on every url the settings route's PORTAL_MODERATOR guard does not
+     * contain it.
+     *
+     * If this default is tightened, this test is the one that must flip to
+     * asserting the actor stays themselves.
+     */
+    public function testPlainMemberCanImpersonateAnotherMemberBecauseTheDefaultIsPermissive(): void
+    {
+        ['portal' => $portal, 'actor' => $actor, 'target' => $target] = $this->createScenario();
+        $portalId = $portal->getId();
+
+        // No moderator promotion, no impersonation grant — factory defaults only.
+        $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
+
+        $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user={$target->getUsername()}");
+
+        self::assertSame(
+            $target->getUsername(),
+            $this->authenticatedUsername(),
+            'a plain member reaches another member via _switch_user — the impersonation default is opt-out',
+        );
+    }
+
+    /**
+     * Characterization of the escalation on top, NOT an endorsement.
+     *
+     * UserProvider::loadUserByIdentifier() special-cases the identifier 'root'
+     * and returns the server-context root account BEFORE any portal scoping, so
+     * the boundary pinned in the test below — the one that stops every other
+     * foreign account — does not apply here. Whether ?_switch_user=root works
+     * therefore rests entirely on SwitchToUserVoter, which grants every
+     * authenticated member.
+     *
+     * If the voter is tightened, this test must flip to asserting the actor
+     * stays themselves.
+     */
+    public function testPlainMemberCanBecomeRoot(): void
+    {
+        ['portal' => $portal, 'actor' => $actor] = $this->createScenario();
+        $portalId = $portal->getId();
+
+        $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
+
+        $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user=root");
+
+        self::assertSame(
+            'root',
+            $this->authenticatedUsername(),
+            'a plain member reaches the server-context root account via _switch_user',
+        );
+    }
+
+    /**
+     * The one boundary that does hold: UserProvider resolves the target inside
+     * the portal from the session, so an account of another portal is not
+     * reachable and the actor keeps their own identity.
+     */
+    public function testSwitchUserCannotReachAnAccountOfAnotherPortal(): void
+    {
+        ['portal' => $portal, 'actor' => $actor] = $this->createScenario();
+        $portalId = $portal->getId();
+
+        $foreignLocal = AuthSourceLocalFactory::createOne(['enabled' => true, 'default' => true]);
+        $foreignPortal = PortalFactory::createOne(['authSources' => [$foreignLocal]]);
+        $foreignAccount = AccountFactory::createOne([
+            'portal' => $foreignPortal,
+            'authSource' => $foreignLocal,
+            'username' => 'foreign.member',
+            'activityState' => Account::ACTIVITY_ACTIVE,
+            'locked' => false,
+        ]);
+
+        $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
+
+        $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user={$foreignAccount->getUsername()}");
+
+        self::assertSame(
+            $actor->getUsername(),
+            $this->authenticatedUsername(),
+            'the portal-scoped lookup in UserProvider keeps a foreign account out of reach',
+        );
+    }
+
+    /**
+     * @return array{portal: mixed, actor: mixed, target: mixed}
+     */
+    private function createScenario(): array
+    {
+        $localSource = AuthSourceLocalFactory::createOne(['enabled' => true, 'default' => true]);
+        $portal = PortalFactory::createOne(['authSources' => [$localSource]]);
+
+        $actor = AccountFactory::createOne([
+            'portal' => $portal,
+            'authSource' => $localSource,
+            'username' => 'plain.member',
+            'activityState' => Account::ACTIVITY_ACTIVE,
+            'locked' => false,
+        ]);
+
+        $target = AccountFactory::createOne([
+            'portal' => $portal,
+            'authSource' => $localSource,
+            'username' => 'other.member',
+            'activityState' => Account::ACTIVITY_ACTIVE,
+            'locked' => false,
+        ]);
+
+        return ['portal' => $portal, 'actor' => $actor, 'target' => $target];
+    }
+
+    private function authenticatedUsername(): ?string
+    {
+        $token = static::getContainer()->get('security.token_storage')->getToken();
+        $user = $token?->getUser();
+
+        return $user instanceof Account ? $user->getUsername() : null;
+    }
+}

--- a/tests/Application/SwitchUserTest.php
+++ b/tests/Application/SwitchUserTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Tests\Application;
 
 use App\Entity\Account;
+use Doctrine\ORM\EntityManagerInterface;
 use Tests\Factory\AccountFactory;
 use Tests\Factory\AuthSourceLocalFactory;
 use Tests\Factory\PortalFactory;
@@ -40,6 +41,7 @@ final class SwitchUserTest extends AbstractApplicationTestCase
         ['portal' => $portal, 'actor' => $actor, 'target' => $target] = $this->createScenario();
         $portalId = $portal->getId();
 
+        $this->promoteToPortalModerator($actor);
         $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
 
         $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user={$target->getUsername()}");
@@ -52,49 +54,45 @@ final class SwitchUserTest extends AbstractApplicationTestCase
     }
 
     /**
-     * Characterization of a permissive default, NOT an endorsement.
+     * The reason the parameter being firewall-wide is not a hole: taking an
+     * account over requires portal moderator status.
      *
      * `cs_user_item::getCanImpersonateAnotherUser()` is an opt-OUT
-     * (`!_issetExtra('DEACTIVATE_LOGIN_AS')`), and SwitchToUserVoter checks
-     * nothing else — no moderator status, no portal-moderation right. A plain
-     * portal member therefore passes CAN_SWITCH_USER, and because the listener
-     * runs on every url the settings route's PORTAL_MODERATOR guard does not
-     * contain it.
-     *
-     * If this default is tightened, this test is the one that must flip to
-     * asserting the actor stays themselves.
+     * (`!_issetExtra('DEACTIVATE_LOGIN_AS')`) and still returns true for a fresh
+     * account, so before the moderator requirement every authenticated member
+     * passed CAN_SWITCH_USER and could impersonate anyone in their portal from
+     * any url. The previous revision of this file asserted exactly that, as a
+     * characterization.
      */
-    public function testPlainMemberCanImpersonateAnotherMemberBecauseTheDefaultIsPermissive(): void
+    public function testPlainMemberCannotImpersonateAnotherMember(): void
     {
         ['portal' => $portal, 'actor' => $actor, 'target' => $target] = $this->createScenario();
         $portalId = $portal->getId();
 
-        // No moderator promotion, no impersonation grant — factory defaults only.
+        // No moderator promotion — factory defaults only.
         $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
 
         $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user={$target->getUsername()}");
 
         self::assertSame(
-            $target->getUsername(),
+            $actor->getUsername(),
             $this->authenticatedUsername(),
-            'a plain member reaches another member via _switch_user — the impersonation default is opt-out',
+            'a plain member must not be able to assume another identity',
         );
     }
 
     /**
-     * Characterization of the escalation on top, NOT an endorsement.
+     * The escalation that came on top, and why the target's portal carries the
+     * rule rather than the actor's status alone.
      *
      * UserProvider::loadUserByIdentifier() special-cases the identifier 'root'
      * and returns the server-context root account BEFORE any portal scoping, so
-     * the boundary pinned in the test below — the one that stops every other
-     * foreign account — does not apply here. Whether ?_switch_user=root works
-     * therefore rests entirely on SwitchToUserVoter, which grants every
-     * authenticated member.
-     *
-     * If the voter is tightened, this test must flip to asserting the actor
-     * stays themselves.
+     * the boundary pinned further below — the one that stops every other foreign
+     * account — does not apply here. Whether ?_switch_user=root works therefore
+     * rests entirely on SwitchToUserVoter, which granted every authenticated
+     * member until the moderator requirement.
      */
-    public function testPlainMemberCanBecomeRoot(): void
+    public function testPlainMemberCannotBecomeRoot(): void
     {
         ['portal' => $portal, 'actor' => $actor] = $this->createScenario();
         $portalId = $portal->getId();
@@ -104,21 +102,47 @@ final class SwitchUserTest extends AbstractApplicationTestCase
         $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user=root");
 
         self::assertSame(
-            'root',
+            $actor->getUsername(),
             $this->authenticatedUsername(),
-            'a plain member reaches the server-context root account via _switch_user',
+            'a plain member must not be able to become root',
         );
     }
 
     /**
-     * The one boundary that does hold: UserProvider resolves the target inside
-     * the portal from the session, so an account of another portal is not
-     * reachable and the actor keeps their own identity.
+     * Not even a portal moderator may become root: the root account has no
+     * portal, so there is no portal to be a moderator of.
+     */
+    public function testPortalModeratorCannotBecomeRoot(): void
+    {
+        ['portal' => $portal, 'actor' => $actor] = $this->createScenario();
+        $portalId = $portal->getId();
+
+        $this->promoteToPortalModerator($actor);
+        $this->loginAsUser($portalId, $actor->getUsername(), $actor->getPlainPassword());
+
+        $this->client->request('GET', "/portal/{$portalId}/enter?_switch_user=root");
+
+        self::assertSame(
+            $actor->getUsername(),
+            $this->authenticatedUsername(),
+            'portal moderation does not reach the server-context root account',
+        );
+    }
+
+    /**
+     * The portal boundary, now enforced by the voter as well. It held before
+     * this change too, but only further downstream: UserProvider resolves the
+     * target inside the portal from the session, so a foreign account was never
+     * reachable — a coincidence rather than a guard. The actor is a moderator
+     * here so the case still tests the boundary and not the new moderator
+     * requirement.
      */
     public function testSwitchUserCannotReachAnAccountOfAnotherPortal(): void
     {
         ['portal' => $portal, 'actor' => $actor] = $this->createScenario();
         $portalId = $portal->getId();
+
+        $this->promoteToPortalModerator($actor);
 
         $foreignLocal = AuthSourceLocalFactory::createOne(['enabled' => true, 'default' => true]);
         $foreignPortal = PortalFactory::createOne(['authSources' => [$foreignLocal]]);
@@ -166,6 +190,20 @@ final class SwitchUserTest extends AbstractApplicationTestCase
         ]);
 
         return ['portal' => $portal, 'actor' => $actor, 'target' => $target];
+    }
+
+    /**
+     * Raises the account's portal-level user row to moderator. Done before the
+     * account authenticates, so no stale cs_user_item is cached.
+     */
+    private function promoteToPortalModerator(Account $account): void
+    {
+        static::getContainer()->get(EntityManagerInterface::class)
+            ->getConnection()
+            ->executeStatement(
+                'UPDATE user SET status = 3 WHERE account_id = ? AND context_id = ?',
+                [$account->getId(), $account->getPortal()?->getId()]
+            );
     }
 
     private function authenticatedUsername(): ?string

--- a/tests/Integration/Security/OidcAuthenticatorTest.php
+++ b/tests/Integration/Security/OidcAuthenticatorTest.php
@@ -12,6 +12,7 @@ use App\Security\OidcAuthenticator;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Tests\Factory\AccountFactory;
 use Tests\Factory\AuthSourceOIDCFactory;
 use Tests\Factory\PortalFactory;
@@ -61,7 +62,7 @@ class OidcAuthenticatorTest extends KernelTestCase
         $oidcAuthenticator = $container->get(OidcAuthenticator::class);
 
         $request = new Request();
-        $request->setSession(new Session());
+        $request->setSession(new Session(new MockArraySessionStorage()));
         $request->attributes->add(['context' => $portal->getId()]);
         $oidcAuthenticator->authenticate($request);
 
@@ -121,7 +122,7 @@ class OidcAuthenticatorTest extends KernelTestCase
         $oidcAuthenticator = $container->get(OidcAuthenticator::class);
 
         $request = new Request();
-        $request->setSession(new Session());
+        $request->setSession(new Session(new MockArraySessionStorage()));
         $request->attributes->add(['context' => $portal->getId()]);
         $oidcAuthenticator->authenticate($request);
 
@@ -181,7 +182,7 @@ class OidcAuthenticatorTest extends KernelTestCase
         $oidcAuthenticator = $container->get(OidcAuthenticator::class);
 
         $request = new Request();
-        $request->setSession(new Session());
+        $request->setSession(new Session(new MockArraySessionStorage()));
         $request->attributes->add(['context' => $portal->getId()]);
         $oidcAuthenticator->authenticate($request);
 


### PR DESCRIPTION
Sicherheits-Backport von 10.5 nach 10.4. Details zu Ursache und Auswirkung stehen in den Tickets, nicht hier.

## Inhalt

| Bereich | 10.5.1 | 10.4.6 |
| --- | --- | --- |
| Kennungsübernahme: Berechtigungsprüfung im `SwitchToUserVoter` | #5437 | #5440 |
| Personen-Druckroute: fehlende Wächter ergänzt | #5438 | #5441 |
| Privatraum-Eintritt: auf den Eigentümer beschränkt | — | #5432 |

Der Übernahme-Fix ist auf 10.4 selbsttragend umgesetzt statt wie auf 10.5 an `UserVoter::PORTAL_MODERATOR` delegiert — das Attribut hat auf diesem Branch nicht die dafür nötige Semantik. Konstruktor und Abhängigkeiten bleiben unverändert.

Zwei weitere Commits sind Voraussetzung für die neuen Tests und übernehmen vorbestehende Korrekturen aus 10.5 (`3f5c8b0d2`, `8ac951280`): Testisolation der Session in `OidcAuthenticatorTest` und die Subjektauflösung bei `ITEM_ENTER` inklusive nullbarem `Portal` in `AccountsRepository::findOneByCredentials`. Beide Defekte sind auf 10.4 vorbestehend und werden erst durch die zusätzlichen Fixtures sichtbar.

## Prüfungen

- volle Testsuite auf diesem Branch grün: 156 Tests, 829 Assertions — gegenüber 3 Fehlern auf dem unveränderten 10.4
- `bin/console lint:container` und `lint:twig` (311 Dateien) ohne Befund
- phpstan auf allen geänderten Quelldateien ohne neue Befunde
- jeder Fix ist durch einen Test abgedeckt, der ohne die Änderung fehlschlägt

Die Tests auf 10.4 sind gegenüber 10.5 eingekürzt, wo die dortige Testinfrastruktur auf diesem Branch fehlt.

## Nicht enthalten

- `88edaaa52` (Ablauffrist der Kennungsübernahme)
- `15a3ab662` (Portalbindung der Kontenverwaltung)

Refs #5432, #5440, #5441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
